### PR TITLE
Binding-decisive multi-armature selection (skin-weight tiebreaks)

### DIFF
--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -359,6 +359,25 @@ def discover_armatures(asset_dir: Path) -> List[ArmatureInput]:
     return armatures
 
 
+# Ordered selection cascade. Each entry is (audit_label, summary_field); the sort
+# key negates each field (higher is better) and _compute_selection_tiebreaker walks
+# the same list so the two can never drift. Binding leads, then the skin-weight
+# signals, then today's bundled scalar as the no-binding fallback.
+_SELECTION_CASCADE: Tuple[Tuple[str, str], ...] = (
+    ("mesh_bound_term", "mesh_bound_term"),
+    ("vertex_group_coverage", "vertex_group_coverage"),
+    ("deform_purity", "deform_purity"),
+    ("score", "ranking_score"),
+    ("mapped_core_targets", "mapped_core_targets"),
+    ("average_confidence", "average_confidence"),
+)
+
+
+def _selection_key(report: dict) -> tuple:
+    summary = report["summary"]
+    return tuple(-summary[field] for _, field in _SELECTION_CASCADE) + (report["armature_name"],)
+
+
 def classify_asset_folder(asset_dir: Path) -> Tuple[dict, dict]:
     asset_dir = asset_dir.resolve()
     if not asset_dir.is_dir():
@@ -370,18 +389,7 @@ def classify_asset_folder(asset_dir: Path) -> Tuple[dict, dict]:
 
     armature_reports = [classify_armature(asset_dir.name, armature_input) for armature_input in armature_inputs]
 
-    def _ranking_key(report: dict) -> tuple:
-        summary = report["summary"]
-        return (
-            -summary["ranking_score"],
-            -summary["mesh_bound_term"],
-            -summary["deform_evidence_term"],
-            -summary["mapped_core_targets"],
-            -summary["average_confidence"],
-            report["armature_name"],
-        )
-
-    ranked_reports = sorted(armature_reports, key=_ranking_key)
+    ranked_reports = sorted(armature_reports, key=_selection_key)
     recommended_report = ranked_reports[0]
     selection_tiebreaker = _compute_selection_tiebreaker(ranked_reports)
     mesh_binding = copy.deepcopy(recommended_report.get("mesh_binding"))
@@ -462,6 +470,8 @@ def _build_ranking_entry(report: dict, selection_tiebreaker: Optional[str]) -> d
         "mesh_bound_term": summary["mesh_bound_term"],
         "deform_evidence_term": summary["deform_evidence_term"],
         "extras_term": summary["extras_term"],
+        "vertex_group_coverage": summary["vertex_group_coverage"],
+        "deform_purity": summary["deform_purity"],
         "primary_input": report["selected_inputs"]["primary"],
     }
     if selection_tiebreaker is not None:
@@ -470,12 +480,11 @@ def _build_ranking_entry(report: dict, selection_tiebreaker: Optional[str]) -> d
 
 
 def _compute_selection_tiebreaker(ranked_reports: List[dict]) -> str:
-    """Identify which step of the ranking cascade decided the top pick.
+    """Identify which step of the selection cascade decided the top pick.
 
-    Returns 'sole_candidate' when there is only one armature, 'score' when
-    the primary ranking_score already separated the top two, or the name of
-    the first cascade step on which the top candidate strictly beats the
-    second-place candidate.
+    Returns 'sole_candidate' when there is only one armature, otherwise the audit
+    label of the first cascade step on which the top candidate strictly beats the
+    second-place candidate, or 'armature_name' when every numeric signal ties.
     """
     if len(ranked_reports) <= 1:
         return "sole_candidate"
@@ -483,16 +492,9 @@ def _compute_selection_tiebreaker(ranked_reports: List[dict]) -> str:
     top_summary = ranked_reports[0]["summary"]
     runner_summary = ranked_reports[1]["summary"]
 
-    if top_summary["ranking_score"] != runner_summary["ranking_score"]:
-        return "score"
-    if top_summary["mesh_bound_term"] != runner_summary["mesh_bound_term"]:
-        return "mesh_bound_term"
-    if top_summary["deform_evidence_term"] != runner_summary["deform_evidence_term"]:
-        return "deform_evidence_term"
-    if top_summary["mapped_core_targets"] != runner_summary["mapped_core_targets"]:
-        return "mapped_core_targets"
-    if top_summary["average_confidence"] != runner_summary["average_confidence"]:
-        return "average_confidence"
+    for label, field in _SELECTION_CASCADE:
+        if top_summary[field] != runner_summary[field]:
+            return label
     return "armature_name"
 
 

--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -1447,6 +1447,24 @@ def _compute_extras_term(extras_preserved: List[dict]) -> float:
     return round(min(math.log1p(len(extras_preserved)) * 0.5, 2.0), 3)
 
 
+def _compute_vertex_group_coverage(vertex_group_bone_hits: int, vertex_group_count: int) -> float:
+    """Fraction of the bound mesh's vertex groups this armature's bones cover (0..1).
+
+    Convention-agnostic skin-weight signal: how much of the skin this armature
+    accounts for. A true deform rig approaches 1.0; a pure control rig is low.
+    """
+    return round(vertex_group_bone_hits / max(vertex_group_count, 1), 3)
+
+
+def _compute_deform_purity(vertex_group_bone_hits: int, armature_bone_count: int) -> float:
+    """Fraction of this armature's bones that actually drive skin (0..1).
+
+    Breaks a coverage tie between a clean deform rig (~1.0) and a bushy superset
+    control rig that copies the deform bone names but adds scaffolding bones (low).
+    """
+    return round(vertex_group_bone_hits / max(armature_bone_count, 1), 3)
+
+
 def _build_armature_summary(
     resolved_targets: Dict[str, dict],
     review_flags: List[str],
@@ -1472,6 +1490,14 @@ def _build_armature_summary(
     )
     deform_evidence_term = _compute_deform_evidence_term(mesh_stats["vertex_group_bone_hits"])
     extras_term = _compute_extras_term(extras_preserved)
+    vertex_group_coverage = _compute_vertex_group_coverage(
+        mesh_stats["vertex_group_bone_hits"],
+        mesh_stats["vertex_group_count"],
+    )
+    deform_purity = _compute_deform_purity(
+        mesh_stats["vertex_group_bone_hits"],
+        len(armature_bones),
+    )
 
     ranking_score = round(
         (len(mapped) * 5.0)
@@ -1496,6 +1522,8 @@ def _build_armature_summary(
         "mesh_bound_term": mesh_bound_term,
         "deform_evidence_term": deform_evidence_term,
         "extras_term": extras_term,
+        "vertex_group_coverage": vertex_group_coverage,
+        "deform_purity": deform_purity,
         "deform_evidence": mesh_stats,
         "ranking_score": ranking_score,
     }

--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -1387,11 +1387,17 @@ def _collect_mesh_binding_stats(
     armature_bone_names_lower: Set[str],
 ) -> dict:
     """Walk mesh_binding once and return the raw stats needed by armature scoring."""
+    empty = {
+        "meshes_count": 0,
+        "has_armature_modifier_link": False,
+        "vertex_group_bone_hits": 0,
+        "vertex_group_count": 0,
+    }
     if not mesh_binding:
-        return {"meshes_count": 0, "has_armature_modifier_link": False, "vertex_group_bone_hits": 0}
+        return dict(empty)
     meshes = mesh_binding.get("meshes") or []
     if not meshes:
-        return {"meshes_count": 0, "has_armature_modifier_link": False, "vertex_group_bone_hits": 0}
+        return dict(empty)
 
     has_armature_modifier_link = False
     vertex_group_names_lower: Set[str] = set()
@@ -1406,6 +1412,7 @@ def _collect_mesh_binding_stats(
         "meshes_count": len(meshes),
         "has_armature_modifier_link": has_armature_modifier_link,
         "vertex_group_bone_hits": len(armature_bone_names_lower & vertex_group_names_lower),
+        "vertex_group_count": len(vertex_group_names_lower),
     }
 
 

--- a/tests/blender_runbook/runbook_multi_armature_selection.py
+++ b/tests/blender_runbook/runbook_multi_armature_selection.py
@@ -1,0 +1,201 @@
+"""
+In-Blender multi-armature selection runbook (Issue #32).
+
+Builds a synthetic scene with TWO armatures both modifier-bound to ONE mesh:
+  - DeformRig: mixamo-named bones that match the mesh's vertex groups (owns skin).
+  - ControlRig: a bushier biped-named rig (incl. toes -> more ASAM targets, higher
+    ranking_score) whose names do NOT match the vertex groups.
+
+Then runs inspector + classifier and asserts the classifier recommends DeformRig
+(because it carries the skin weights), with selection_tiebreaker
+== 'vertex_group_coverage'. Under the pre-#32 ranking ControlRig would have won.
+
+This is NOT a pytest test: it requires an interactive Blender session and is not
+discovered by `python -m unittest`. Run via VS Code `Blender: Run Script` or a
+Blender MCP `execute code` call. It builds its own objects, so any open scene works.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.append(_HERE)
+
+import bpy  # noqa: E402
+import bmesh  # noqa: E402
+
+from _harness import ensure_src_on_path, reload_pipeline_modules  # noqa: E402
+
+
+# (name, head, tail, parent). Compact mixamo deform skeleton (no toes).
+_DEFORM_BONES = [
+    ("mixamorig:Hips", (0, 0, 0.95), (0, 0, 1.05), None),
+    ("mixamorig:Spine", (0, 0, 1.05), (0, 0, 1.2), "mixamorig:Hips"),
+    ("mixamorig:Spine1", (0, 0, 1.2), (0, 0, 1.35), "mixamorig:Spine"),
+    ("mixamorig:Spine2", (0, 0, 1.35), (0, 0, 1.45), "mixamorig:Spine1"),
+    ("mixamorig:Neck", (0, 0, 1.45), (0, 0, 1.6), "mixamorig:Spine2"),
+    ("mixamorig:Head", (0, 0, 1.6), (0, 0, 1.75), "mixamorig:Neck"),
+    ("mixamorig:LeftArm", (0, 0.18, 1.45), (0, 0.45, 1.45), "mixamorig:Spine2"),
+    ("mixamorig:LeftForeArm", (0, 0.45, 1.45), (0, 0.7, 1.45), "mixamorig:LeftArm"),
+    ("mixamorig:LeftHand", (0, 0.7, 1.45), (0, 0.8, 1.45), "mixamorig:LeftForeArm"),
+    ("mixamorig:RightArm", (0, -0.18, 1.45), (0, -0.45, 1.45), "mixamorig:Spine2"),
+    ("mixamorig:RightForeArm", (0, -0.45, 1.45), (0, -0.7, 1.45), "mixamorig:RightArm"),
+    ("mixamorig:RightHand", (0, -0.7, 1.45), (0, -0.8, 1.45), "mixamorig:RightForeArm"),
+    ("mixamorig:LeftUpLeg", (0, 0.1, 0.95), (0, 0.1, 0.55), "mixamorig:Hips"),
+    ("mixamorig:LeftLeg", (0, 0.1, 0.55), (0, 0.1, 0.1), "mixamorig:LeftUpLeg"),
+    ("mixamorig:LeftFoot", (0, 0.1, 0.1), (0.15, 0.1, 0.0), "mixamorig:LeftLeg"),
+    ("mixamorig:RightUpLeg", (0, -0.1, 0.95), (0, -0.1, 0.55), "mixamorig:Hips"),
+    ("mixamorig:RightLeg", (0, -0.1, 0.55), (0, -0.1, 0.1), "mixamorig:RightUpLeg"),
+    ("mixamorig:RightFoot", (0, -0.1, 0.1), (0.15, -0.1, 0.0), "mixamorig:RightLeg"),
+]
+
+# Bushier biped control rig WITH toes; names do NOT match the mixamo vertex groups.
+_CONTROL_BONES = [
+    ("Bip01 COM", (0, 0, 0), (0, 0, 0.95), None),
+    ("Bip01 Pelvis", (0, 0, 0.95), (0, 0, 1.05), "Bip01 COM"),
+    ("Bip01 Spine0", (0, 0, 1.05), (0, 0, 1.25), "Bip01 Pelvis"),
+    ("Bip01 Spine1", (0, 0, 1.25), (0, 0, 1.45), "Bip01 Spine0"),
+    ("Bip01 Neck", (0, 0, 1.45), (0, 0, 1.6), "Bip01 Spine1"),
+    ("Bip01 Head", (0, 0, 1.6), (0, 0, 1.75), "Bip01 Neck"),
+    ("Bip01 LUpperArm", (0, 0.18, 1.45), (0, 0.45, 1.45), "Bip01 Spine1"),
+    ("Bip01 LForeArm", (0, 0.45, 1.45), (0, 0.7, 1.45), "Bip01 LUpperArm"),
+    ("Bip01 LHand", (0, 0.7, 1.45), (0, 0.8, 1.45), "Bip01 LForeArm"),
+    ("Bip01 RUpperArm", (0, -0.18, 1.45), (0, -0.45, 1.45), "Bip01 Spine1"),
+    ("Bip01 RForeArm", (0, -0.45, 1.45), (0, -0.7, 1.45), "Bip01 RUpperArm"),
+    ("Bip01 RHand", (0, -0.7, 1.45), (0, -0.8, 1.45), "Bip01 RForeArm"),
+    ("Bip01 LThigh", (0, 0.1, 0.95), (0, 0.1, 0.55), "Bip01 Pelvis"),
+    ("Bip01 LCalf", (0, 0.1, 0.55), (0, 0.1, 0.1), "Bip01 LThigh"),
+    ("Bip01 LFoot", (0, 0.1, 0.1), (0.15, 0.1, 0.0), "Bip01 LCalf"),
+    ("Bip01 LToe0", (0.15, 0.1, 0.0), (0.25, 0.1, 0.0), "Bip01 LFoot"),
+    ("Bip01 RThigh", (0, -0.1, 0.95), (0, -0.1, 0.55), "Bip01 Pelvis"),
+    ("Bip01 RCalf", (0, -0.1, 0.55), (0, -0.1, 0.1), "Bip01 RThigh"),
+    ("Bip01 RFoot", (0, -0.1, 0.1), (0.15, -0.1, 0.0), "Bip01 RCalf"),
+    ("Bip01 RToe0", (0.15, -0.1, 0.0), (0.25, -0.1, 0.0), "Bip01 RFoot"),
+]
+
+_RUNBOOK_OBJECT_NAMES = ("DeformRig", "ControlRig", "BodyMesh")
+
+
+def _purge_previous_runbook_objects():
+    """Remove objects/armatures/meshes left by a prior run so names stay clean."""
+    for name in _RUNBOOK_OBJECT_NAMES:
+        obj = bpy.data.objects.get(name)
+        if obj is not None:
+            bpy.data.objects.remove(obj, do_unlink=True)
+    for arm in list(bpy.data.armatures):
+        if arm.name.startswith(("DeformRig", "ControlRig")):
+            bpy.data.armatures.remove(arm)
+
+
+def _make_armature(name, bone_defs):
+    arm_data = bpy.data.armatures.new(name + "_data")
+    arm_obj = bpy.data.objects.new(name, arm_data)
+    bpy.context.scene.collection.objects.link(arm_obj)
+    bpy.context.view_layer.objects.active = arm_obj
+    bpy.ops.object.mode_set(mode="EDIT")
+    created = {}
+    for bname, head, tail, _parent in bone_defs:
+        edit_bone = arm_data.edit_bones.new(bname)
+        edit_bone.head = head
+        edit_bone.tail = tail
+        created[bname] = edit_bone
+    for bname, _head, _tail, parent in bone_defs:
+        if parent is not None:
+            created[bname].parent = created[parent]
+    bpy.ops.object.mode_set(mode="OBJECT")
+    return arm_obj
+
+
+def _make_bound_mesh(name, vertex_group_names, armatures):
+    mesh = bpy.data.meshes.new(name + "_data")
+    bm = bmesh.new()
+    bmesh.ops.create_cube(bm, size=0.4)
+    bm.to_mesh(mesh)
+    bm.free()
+    obj = bpy.data.objects.new(name, mesh)
+    bpy.context.scene.collection.objects.link(obj)
+    for group_name in vertex_group_names:
+        obj.vertex_groups.new(name=group_name)
+    for arm in armatures:
+        modifier = obj.modifiers.new(name="Armature_" + arm.name, type="ARMATURE")
+        modifier.object = arm
+    return obj
+
+
+def _build_scene():
+    _purge_previous_runbook_objects()
+    deform = _make_armature("DeformRig", _DEFORM_BONES)
+    control = _make_armature("ControlRig", _CONTROL_BONES)
+    vertex_groups = [bone[0] for bone in _DEFORM_BONES]  # mesh skinned to the deform rig
+    _make_bound_mesh("BodyMesh", vertex_groups, [deform, control])
+
+
+def main():
+    print("=" * 60)
+    print("MULTI-ARMATURE SELECTION RUNBOOK (Issue #32)")
+    print("=" * 60)
+
+    ensure_src_on_path()
+    reload_pipeline_modules()
+
+    _build_scene()
+
+    output_root = tempfile.mkdtemp(prefix="open_jaywalker_multiarm_runbook_")
+    os.environ["OPEN_JAYWALKER_OUTPUT_ROOT"] = output_root
+    print("Runbook output dir: {0}".format(output_root))
+
+    from inspector import inspect_scene
+    from classifier import write_asset_report
+
+    inspect_result = inspect_scene()
+    if not inspect_result:
+        raise RuntimeError("Inspector exported nothing; expected two armatures + a mesh.")
+    asset_dir = Path(inspect_result["output_dir"]).resolve()
+    report = write_asset_report(asset_dir)[0]
+
+    recommended = report["recommended_primary_armature"]
+    ranking = report["asset_summary"]["ranking"]
+    top = ranking[0]
+    by_name = {entry["armature_name"]: entry for entry in ranking}
+
+    print("Discovered armatures: {0}".format(report["asset_summary"]["discovered_armatures"]))
+    for entry in ranking:
+        print(
+            "  {0}: mesh_bound={1} coverage={2} purity={3} score={4} tiebreak={5}".format(
+                entry["armature_name"],
+                entry["mesh_bound_term"],
+                entry["vertex_group_coverage"],
+                entry["deform_purity"],
+                entry["ranking_score"],
+                entry.get("selection_tiebreaker"),
+            )
+        )
+
+    failures = []
+    if recommended != "DeformRig":
+        failures.append("expected recommended DeformRig, got {0}".format(recommended))
+    if top.get("selection_tiebreaker") != "vertex_group_coverage":
+        failures.append(
+            "expected tiebreaker vertex_group_coverage, got {0}".format(top.get("selection_tiebreaker"))
+        )
+    if by_name.get("DeformRig", {}).get("mesh_bound_term") != 10.0:
+        failures.append("DeformRig not fully mesh-bound (expected mesh_bound_term 10.0)")
+    if by_name.get("ControlRig", {}).get("mesh_bound_term") != 10.0:
+        failures.append("ControlRig not fully mesh-bound (expected mesh_bound_term 10.0)")
+
+    print("-" * 60)
+    print("Overall: {0}".format("PASS" if not failures else "FAIL"))
+    for failure in failures:
+        print("  - {0}".format(failure))
+
+
+if __name__ == "__main__":
+    main()
+else:
+    main()

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -907,61 +907,71 @@ class ArmatureSelectionCascadeTests(unittest.TestCase):
         self.assertEqual(len(ranking), 1)
         self.assertEqual(ranking[0]["selection_tiebreaker"], "sole_candidate")
 
-    def _make_report(self, name, score, mesh_bound, deform_evidence, mapped, avg_conf):
+    def _make_report(self, name, score, mesh_bound, coverage, purity, mapped, avg_conf):
         return {
             "armature_name": name,
             "summary": {
                 "ranking_score": score,
                 "mesh_bound_term": mesh_bound,
-                "deform_evidence_term": deform_evidence,
+                "vertex_group_coverage": coverage,
+                "deform_purity": purity,
                 "mapped_core_targets": mapped,
                 "average_confidence": avg_conf,
             },
         }
 
     def test_tiebreaker_sole_candidate(self):
-        reports = [self._make_report("only", 100.0, 10.0, 6.0, 22, 0.9)]
+        reports = [self._make_report("only", 100.0, 10.0, 1.0, 1.0, 22, 0.9)]
         self.assertEqual(_compute_selection_tiebreaker(reports), "sole_candidate")
 
-    def test_tiebreaker_score_when_scores_differ(self):
+    def test_tiebreaker_mesh_bound_decides_first(self):
         reports = [
-            self._make_report("a", 100.0, 0.0, 0.0, 20, 0.9),
-            self._make_report("b", 90.0, 10.0, 6.0, 22, 0.9),
+            self._make_report("bound", 90.0, 10.0, 0.5, 0.5, 20, 0.9),
+            self._make_report("unbound", 120.0, 0.0, 0.0, 0.0, 28, 0.95),
         ]
-        self.assertEqual(_compute_selection_tiebreaker(reports), "score")
-
-    def test_tiebreaker_mesh_bound_when_scores_tie(self):
-        reports = [
-            self._make_report("a", 100.0, 10.0, 6.0, 22, 0.9),
-            self._make_report("b", 100.0, 0.0, 6.0, 22, 0.9),
-        ]
+        # Even though "unbound" has a higher ranking_score, binding leads the cascade.
         self.assertEqual(_compute_selection_tiebreaker(reports), "mesh_bound_term")
 
-    def test_tiebreaker_deform_evidence_when_score_and_mesh_bound_tie(self):
+    def test_tiebreaker_coverage_when_binding_ties(self):
         reports = [
-            self._make_report("a", 100.0, 10.0, 6.0, 22, 0.9),
-            self._make_report("b", 100.0, 10.0, 4.0, 22, 0.9),
+            self._make_report("deform", 100.0, 10.0, 1.0, 1.0, 22, 0.9),
+            self._make_report("control", 120.0, 10.0, 0.1, 0.1, 28, 0.95),
         ]
-        self.assertEqual(_compute_selection_tiebreaker(reports), "deform_evidence_term")
+        self.assertEqual(_compute_selection_tiebreaker(reports), "vertex_group_coverage")
 
-    def test_tiebreaker_mapped_targets_when_upstream_tie(self):
+    def test_tiebreaker_purity_when_coverage_ties(self):
         reports = [
-            self._make_report("a", 100.0, 10.0, 6.0, 24, 0.9),
-            self._make_report("b", 100.0, 10.0, 6.0, 22, 0.9),
+            self._make_report("deform", 100.0, 10.0, 1.0, 1.0, 22, 0.9),
+            self._make_report("superset", 120.0, 10.0, 1.0, 0.2, 28, 0.95),
+        ]
+        self.assertEqual(_compute_selection_tiebreaker(reports), "deform_purity")
+
+    def test_tiebreaker_score_when_binding_and_skin_signals_tie(self):
+        reports = [
+            self._make_report("a", 110.0, 0.0, 0.0, 0.0, 24, 0.9),
+            self._make_report("b", 100.0, 0.0, 0.0, 0.0, 22, 0.9),
+        ]
+        # No armature bound: cascade falls through to ranking_score (today's behavior).
+        self.assertEqual(_compute_selection_tiebreaker(reports), "score")
+
+    def test_tiebreaker_mapped_targets_when_score_ties(self):
+        reports = [
+            self._make_report("a", 100.0, 10.0, 1.0, 1.0, 24, 0.9),
+            self._make_report("b", 100.0, 10.0, 1.0, 1.0, 22, 0.9),
         ]
         self.assertEqual(_compute_selection_tiebreaker(reports), "mapped_core_targets")
 
     def test_tiebreaker_confidence_when_mapped_ties(self):
         reports = [
-            self._make_report("a", 100.0, 10.0, 6.0, 22, 0.95),
-            self._make_report("b", 100.0, 10.0, 6.0, 22, 0.9),
+            self._make_report("a", 100.0, 10.0, 1.0, 1.0, 22, 0.95),
+            self._make_report("b", 100.0, 10.0, 1.0, 1.0, 22, 0.9),
         ]
         self.assertEqual(_compute_selection_tiebreaker(reports), "average_confidence")
 
     def test_tiebreaker_armature_name_when_all_numeric_signals_tie(self):
         reports = [
-            self._make_report("a", 100.0, 10.0, 6.0, 22, 0.9),
-            self._make_report("b", 100.0, 10.0, 6.0, 22, 0.9),
+            self._make_report("a", 100.0, 10.0, 1.0, 1.0, 22, 0.9),
+            self._make_report("b", 100.0, 10.0, 1.0, 1.0, 22, 0.9),
         ]
         self.assertEqual(_compute_selection_tiebreaker(reports), "armature_name")
 

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -20,6 +20,8 @@ from phase3_classifier.classifier import (  # noqa: E402
     _compute_mesh_bound_term,
     _compute_deform_evidence_term,
     _compute_extras_term,
+    _compute_vertex_group_coverage,
+    _compute_deform_purity,
     _compute_selection_tiebreaker,
     _detect_convention,
     _normalize_bone_name,
@@ -722,6 +724,38 @@ class Phase3ClassifierTests(unittest.TestCase):
         # planar = sqrt(0.086318**2 + 0.009727**2) ~= 0.086865
         self.assertAlmostEqual(magnitude, 0.086865, places=4)
 
+    def test_summary_emits_coverage_and_purity_fields(self):
+        bones = [
+            _bone("Hip", None, (0.0, 0.0, 1.0), (0.0, 0.0, 1.1)),
+            _bone("Lower_Spine", "Hip", (0.0, 0.0, 1.1), (0.0, 0.0, 1.25)),
+            _bone("Upper_Spine", "Lower_Spine", (0.0, 0.0, 1.25), (0.0, 0.0, 1.45)),
+        ]
+        chains = {
+            "spine": [["Lower_Spine", "Upper_Spine"]],
+            "leg": {"left": [], "right": [], "unsided": []},
+            "arm": {"left": [], "right": [], "unsided": []},
+        }
+        binding = {
+            "armature_object_name": "Rig",
+            "meshes": [
+                {
+                    "mesh_name": "BodyMesh",
+                    "modifiers": [{"type": "ARMATURE", "object": "Rig"}],
+                    "vertex_groups": ["Hip", "Lower_Spine", "Upper_Spine"],
+                }
+            ],
+        }
+        asset_dir = _write_single_armature_asset(
+            "coverage_fields", "Rig", bones, chains, None, binding
+        )
+        report, _, _, _ = write_asset_report(asset_dir)
+        summary = report["armatures"][0]["summary"]
+        self.assertIn("vertex_group_coverage", summary)
+        self.assertIn("deform_purity", summary)
+        self.assertEqual(summary["vertex_group_coverage"], 1.0)
+        self.assertEqual(summary["deform_purity"], 1.0)
+        self.assertEqual(summary["deform_evidence"]["vertex_group_count"], 3)
+
 
 class ArmatureScoringHelperTests(unittest.TestCase):
     def test_mesh_bound_term_zero_when_meshes_count_zero(self):
@@ -824,6 +858,26 @@ class ArmatureScoringHelperTests(unittest.TestCase):
     def test_extras_term_caps_at_two(self):
         extras = [{"bone_name": "bone_{}".format(i)} for i in range(200)]
         self.assertEqual(_compute_extras_term(extras), 2.0)
+
+
+class SkinWeightSignalTests(unittest.TestCase):
+    def test_coverage_is_hits_over_vertex_group_count(self):
+        self.assertEqual(_compute_vertex_group_coverage(8, 10), 0.8)
+
+    def test_coverage_full_when_all_groups_hit(self):
+        self.assertEqual(_compute_vertex_group_coverage(20, 20), 1.0)
+
+    def test_coverage_zero_guard_when_no_vertex_groups(self):
+        self.assertEqual(_compute_vertex_group_coverage(0, 0), 0.0)
+
+    def test_purity_is_hits_over_bone_count(self):
+        self.assertEqual(_compute_deform_purity(20, 80), 0.25)
+
+    def test_purity_full_for_pure_deform_rig(self):
+        self.assertEqual(_compute_deform_purity(20, 20), 1.0)
+
+    def test_purity_zero_guard_when_no_bones(self):
+        self.assertEqual(_compute_deform_purity(0, 0), 0.0)
 
 
 class ArmatureSelectionCascadeTests(unittest.TestCase):

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -136,6 +136,80 @@ def _write_single_armature_asset(
     return asset_dir
 
 
+def _mesh_binding_for(armature_name, vertex_groups):
+    """A mesh-binding where `armature_name` modifier-drives BodyMesh with the
+    given vertex-group names (so meshes_count=1 and has_armature_modifier_link)."""
+    return {
+        "armature_object_name": armature_name,
+        "meshes": [
+            {
+                "mesh_name": "BodyMesh",
+                "armature_link": "modifier",
+                "modifiers": [{"stack_index": 0, "type": "ARMATURE", "name": "Armature", "object": armature_name}],
+                "vertex_groups": list(vertex_groups),
+                "vertex_group_stats": {"non_empty_group_count": len(vertex_groups), "per_group": []},
+                "material_slots": [],
+                "warnings": [],
+            }
+        ],
+    }
+
+
+def _write_multi_armature_asset(asset_name, armatures):
+    """Write one asset dir containing several `<armature>_all.json` files.
+
+    `armatures` is a list of (armature_name, bones, chains, mesh_binding|None).
+    """
+    temp_root = Path(tempfile.mkdtemp(prefix="phase3_multi_"))
+    asset_dir = temp_root / asset_name
+    asset_dir.mkdir(parents=True, exist_ok=True)
+    for armature_name, bones, chains, mesh_binding in armatures:
+        hierarchy = {bone["name"]: [] for bone in bones}
+        for bone in bones:
+            parent = bone["parent"]
+            if parent in hierarchy:
+                hierarchy[parent].append(bone["name"])
+        payload = {
+            "armature_name": armature_name,
+            "source_file": f"{asset_name}.blend",
+            "filter": None,
+            "bone_count": len(bones),
+            "hierarchy": hierarchy,
+            "bones": bones,
+            "chains": chains,
+        }
+        if mesh_binding is not None:
+            payload["mesh_binding"] = mesh_binding
+        with (asset_dir / f"{armature_name}_all.json").open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+    return asset_dir
+
+
+def _mixamo_character_without_toes():
+    """Full mixamo skeleton minus the two ToeBase bones (so Full_Toes go unmapped)."""
+    bones, chains = _mixamo_character()
+    drop = {"mixamorig:LeftToeBase", "mixamorig:RightToeBase"}
+    bones = [b for b in bones if b["name"] not in drop]
+    chains = {
+        "spine": chains["spine"],
+        "leg": {side: [[n for n in chain if n not in drop] for chain in chains["leg"][side]] for side in chains["leg"]},
+        "arm": chains["arm"],
+    }
+    return bones, chains
+
+
+def _mixamo_with_extra_control_bones(extra_count=60):
+    """Mixamo deform skeleton PLUS scaffolding bones absent from any vertex group.
+
+    Covers the same vertex groups as the deform rig (so coverage ties) but has far
+    lower deform purity (most bones don't drive skin)."""
+    bones, chains = _mixamo_character()
+    root = bones[0]["name"]
+    for index in range(extra_count):
+        bones.append(_bone(f"mixamorig:CTRL_Twist_{index}", root, (0.5, 0.0, 1.0), (0.5, 0.0, 1.05)))
+    return bones, chains
+
+
 def _biped_character():
     bones = [
         _bone("Bip01 COM", None, (0.0, 0.0, 0.0), (0.0, 0.0, 0.95)),
@@ -1136,6 +1210,46 @@ class FixtureStabilityTests(unittest.TestCase):
             self.assertNotIn("character_decomposition", report["asset_summary"], asset_name)
             self.assertNotIn("characters", build_plan, asset_name)
             self.assertIn("semantic_mapping", report, asset_name)
+
+
+class MultiArmatureSelectionTests(unittest.TestCase):
+    def test_deform_rig_wins_over_bushier_control_rig_on_binding_tie(self):
+        # DeformRig: mixamo (no toes) -> its bone names ARE the mesh's vertex groups.
+        deform_bones, deform_chains = _mixamo_character_without_toes()
+        deform_vgs = [b["name"] for b in deform_bones]
+        # ControlRig: full biped (incl. toes) -> maps MORE ASAM targets (higher
+        # ranking_score) but its biped names do NOT match the mixamo vertex groups.
+        control_bones, control_chains = _biped_character()
+
+        asset_dir = _write_multi_armature_asset(
+            "deform_vs_control",
+            [
+                ("DeformRig", deform_bones, deform_chains, _mesh_binding_for("DeformRig", deform_vgs)),
+                ("ControlRig", control_bones, control_chains, _mesh_binding_for("ControlRig", deform_vgs)),
+            ],
+        )
+        report, build_plan, _, _ = write_asset_report(asset_dir)
+
+        self.assertEqual(report["recommended_primary_armature"], "DeformRig")
+        self.assertEqual(build_plan["recommended_primary_armature"], "DeformRig")
+
+        ranking = report["asset_summary"]["ranking"]
+        top = ranking[0]
+        self.assertEqual(top["armature_name"], "DeformRig")
+        self.assertEqual(top["selection_tiebreaker"], "vertex_group_coverage")
+        by_name = {entry["armature_name"]: entry for entry in ranking}
+        self.assertEqual(by_name["DeformRig"]["mesh_bound_term"], 10.0)
+        self.assertEqual(by_name["ControlRig"]["mesh_bound_term"], 10.0)
+        self.assertGreater(
+            by_name["DeformRig"]["vertex_group_coverage"],
+            by_name["ControlRig"]["vertex_group_coverage"],
+        )
+        # The deform rig wins DESPITE a lower bundled ranking_score (pre-#32 the
+        # bushier control rig would have been selected).
+        self.assertGreater(
+            by_name["ControlRig"]["ranking_score"],
+            by_name["DeformRig"]["ranking_score"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -749,7 +749,12 @@ class ArmatureScoringHelperTests(unittest.TestCase):
         result = _collect_mesh_binding_stats(None, "rig", {"spine"})
         self.assertEqual(
             result,
-            {"meshes_count": 0, "has_armature_modifier_link": False, "vertex_group_bone_hits": 0},
+            {
+                "meshes_count": 0,
+                "has_armature_modifier_link": False,
+                "vertex_group_bone_hits": 0,
+                "vertex_group_count": 0,
+            },
         )
 
     def test_collect_mesh_binding_stats_empty_meshes(self):
@@ -775,6 +780,19 @@ class ArmatureScoringHelperTests(unittest.TestCase):
         result = _collect_mesh_binding_stats(binding, "rig", {"spine", "head"})
         self.assertEqual(result["meshes_count"], 1)
         self.assertTrue(result["has_armature_modifier_link"])
+        self.assertEqual(result["vertex_group_bone_hits"], 2)
+
+    def test_collect_mesh_binding_stats_reports_vertex_group_count(self):
+        binding = {
+            "meshes": [
+                {
+                    "modifiers": [{"type": "ARMATURE", "object": "rig"}],
+                    "vertex_groups": ["spine", "head", "extra_mask"],
+                }
+            ]
+        }
+        result = _collect_mesh_binding_stats(binding, "rig", {"spine", "head"})
+        self.assertEqual(result["vertex_group_count"], 3)
         self.assertEqual(result["vertex_group_bone_hits"], 2)
 
     def test_collect_mesh_binding_stats_modifier_to_other_armature(self):

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -1251,6 +1251,56 @@ class MultiArmatureSelectionTests(unittest.TestCase):
             by_name["DeformRig"]["ranking_score"],
         )
 
+    def test_superset_control_rig_loses_on_deform_purity(self):
+        deform_bones, deform_chains = _mixamo_character()
+        deform_vgs = [b["name"] for b in deform_bones]
+        # ControlRig contains all deform names (coverage ~1.0 too) + 60 scaffolding bones.
+        control_bones, control_chains = _mixamo_with_extra_control_bones(60)
+
+        asset_dir = _write_multi_armature_asset(
+            "superset_control",
+            [
+                ("DeformRig", deform_bones, deform_chains, _mesh_binding_for("DeformRig", deform_vgs)),
+                ("ControlRig", control_bones, control_chains, _mesh_binding_for("ControlRig", deform_vgs)),
+            ],
+        )
+        report, _, _, _ = write_asset_report(asset_dir)
+
+        self.assertEqual(report["recommended_primary_armature"], "DeformRig")
+        top = report["asset_summary"]["ranking"][0]
+        self.assertEqual(top["selection_tiebreaker"], "deform_purity")
+        by_name = {e["armature_name"]: e for e in report["asset_summary"]["ranking"]}
+        self.assertEqual(
+            by_name["DeformRig"]["vertex_group_coverage"],
+            by_name["ControlRig"]["vertex_group_coverage"],
+        )
+        self.assertGreater(
+            by_name["DeformRig"]["deform_purity"],
+            by_name["ControlRig"]["deform_purity"],
+        )
+
+    def test_no_binding_falls_back_to_ranking_score(self):
+        full_bones, full_chains = _biped_character()
+        partial_bones, partial_chains = _mixamo_character_without_toes()
+        # Neither armature has a mesh_binding -> both mesh_bound_term == 0.
+        asset_dir = _write_multi_armature_asset(
+            "no_binding",
+            [
+                ("FullRig", full_bones, full_chains, None),
+                ("PartialRig", partial_bones, partial_chains, None),
+            ],
+        )
+        report, _, _, _ = write_asset_report(asset_dir)
+
+        ranking = report["asset_summary"]["ranking"]
+        by_name = {e["armature_name"]: e for e in ranking}
+        self.assertEqual(by_name["FullRig"]["mesh_bound_term"], 0.0)
+        self.assertEqual(by_name["PartialRig"]["mesh_bound_term"], 0.0)
+        # No binding: the better-mapped rig wins on the bundled scalar, as today.
+        winner = report["recommended_primary_armature"]
+        self.assertEqual(winner, max(by_name, key=lambda n: by_name[n]["ranking_score"]))
+        self.assertEqual(ranking[0]["selection_tiebreaker"], "score")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -961,7 +961,9 @@ class ArmatureSelectionCascadeTests(unittest.TestCase):
 
         ranking = report["asset_summary"]["ranking"]
         self.assertEqual(ranking[0]["armature_name"], "rig")
-        self.assertEqual(ranking[0]["selection_tiebreaker"], "score")
+        # rig is mesh-bound and metarig is not, so the binding step of the cascade
+        # decides the pick (more truthful than the old bundled-"score" audit).
+        self.assertEqual(ranking[0]["selection_tiebreaker"], "mesh_bound_term")
         self.assertNotIn("selection_tiebreaker", ranking[1])
 
     def test_lowpoly_ranking_entries_include_new_terms(self):


### PR DESCRIPTION
## Summary

When several armatures are bound to the same mesh, the classifier now selects the
one that actually carries the skin weights (the deform rig) instead of the bushier
control rig that merely maps more ASAM targets.

Selection is now a **binding-decisive cascade** rather than `ranking_score`-first:

1. `mesh_bound_term` — is the armature modifier-bound to a mesh at all
2. `vertex_group_coverage` — fraction of the bound mesh's vertex groups this rig's bones cover
3. `deform_purity` — fraction of this rig's bones that actually drive skin
4. `ranking_score` — today's bundled scalar (the no-binding fallback, unchanged)
5. `mapped_core_targets` → `average_confidence` → `armature_name`

The sort key and the `selection_tiebreaker` audit string are unified behind a single
ordered `_SELECTION_CASCADE`, so they cannot drift. When no armature is mesh-bound,
the cascade falls through to `ranking_score`, preserving prior behavior (incl. #24's
inspector false-negative protection).

The two skin-weight signals are convention-agnostic name-set counts over data the
inspector already exports — no weight mapping, no naming-convention assumptions.
`ranking_score` is emitted unchanged.

## Changes

- `classifier.py`: add `vertex_group_count` to mesh-binding stats; compute and emit
  `vertex_group_coverage` and `deform_purity` per armature; replace the
  `ranking_score`-first sort with `_SELECTION_CASCADE` + `_selection_key`; rewrite
  `_compute_selection_tiebreaker` to walk the same cascade; mirror new fields into
  ranking entries.
- `tests/test_phase3_classifier.py`: signal-math unit tests, summary-emission test,
  rewritten cascade/tiebreaker tests, end-to-end tests (deform rig beats bushier
  control rig on a binding tie; superset rig loses on purity; no-binding fallback to
  score), and the updated LowPoly audit assertion.
- `tests/blender_runbook/runbook_multi_armature_selection.py`: live in-Blender runbook
  that builds a two-armature / one-mesh scene and asserts the deform rig is selected.

## Verification

- `python -m unittest discover tests` → **192 tests, OK**.
- Live Blender runbook (clean scene) → **Overall: PASS**:
  `DeformRig` (coverage=1.0) selected over `ControlRig` (coverage=0.0) **despite**
  `ControlRig` having a higher bundled `ranking_score` (113.18 > 107.43), with
  `selection_tiebreaker == vertex_group_coverage`.
- Single-character / crowd fixtures: selection outcomes unchanged (only additive
  fields and audit strings differ).
