### PR TITLE
refactor(builder): close deferred #33 review cleanups (#34)

### DIFF
--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -50,21 +50,13 @@ REQUIRED_PLAN_FIELDS = {
 }
 
 def load_builder_inputs(asset_dir: Path) -> Tuple[dict, dict]:
-    """Load classifier and build-plan JSON inputs for the builder."""
-    asset_dir = Path(asset_dir).resolve()
-    report_path = asset_dir / "classifier_report.json"
-    plan_path = asset_dir / "build_plan.json"
+    """Load classifier and build-plan JSON inputs, then validate the flat shape.
 
-    if not report_path.exists():
-        raise FileNotFoundError("Missing classifier_report.json in {0}".format(asset_dir))
-    if not plan_path.exists():
-        raise FileNotFoundError("Missing build_plan.json in {0}".format(asset_dir))
-
-    with report_path.open("r", encoding="utf-8") as handle:
-        classifier_report = json.load(handle)
-    with plan_path.open("r", encoding="utf-8") as handle:
-        build_plan = json.load(handle)
-
+    Delegates the path resolution + missing-file + JSON parsing to
+    `read_builder_inputs`; the only thing this adds is `validate_builder_inputs`,
+    so the flat-shape callers and the no-validate (crowd) callers share one loader.
+    """
+    classifier_report, build_plan = read_builder_inputs(asset_dir)
     validate_builder_inputs(classifier_report, build_plan)
     return classifier_report, build_plan
 
@@ -144,15 +136,16 @@ def wrapper_collection_name(asset_name: str) -> str:
     return "ASAM_{0}".format(asset_name)
 
 
-def apply_character_naming(spec: dict, asset_name: str, character_id: str) -> dict:
-    """Override the generated collection/group-root/armature names with per-character ones.
+def apply_character_naming(spec: dict, asset_name: str, character_id: str) -> None:
+    """Override the generated collection/group-root/armature names in place.
 
     Object names are global in bpy.data, so each character needs a unique suffix.
+    Mutates `spec` and returns None (single-purpose API; callers keep their own
+    reference to `spec`).
     """
     spec["generated_collection_name"] = "ASAM_{0}_{1}".format(asset_name, character_id)
     spec["group_root_name"] = "Grp_Root_{0}".format(character_id)
     spec["generated_armature_name"] = "Armature_{0}_{1}".format(asset_name, character_id)
-    return spec
 
 
 def read_builder_inputs(asset_dir: Path) -> Tuple[dict, dict]:
@@ -732,8 +725,8 @@ def build_character_specs_from_asset_dir(asset_dir: Path) -> dict:
     classifier_report, build_plan = read_builder_inputs(asset_dir)
 
     if not is_crowd_plan(build_plan):
-        # Unchanged single-character path.
-        validate_builder_inputs(classifier_report, build_plan)
+        # Unchanged single-character path. build_armature_spec validates its inputs,
+        # so no separate validate_builder_inputs call is needed here.
         source_bones = build_source_bone_index_from_export(
             asset_dir, build_plan["recommended_primary_armature"]
         )

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -1931,8 +1931,10 @@ class CrowdBlenderTests(unittest.TestCase):
     def test_build_crowd_in_blender_creates_wrapper_with_children(self):
         from asam_human_builder.builder import apply_character_naming
         from asam_human_builder.blender_builder import build_crowd_in_blender
-        spec_a = apply_character_naming(_minimal_crowd_build_spec(), "crowd", "Hero000")
-        spec_b = apply_character_naming(_minimal_crowd_build_spec(), "crowd", "Hero001")
+        spec_a = _minimal_crowd_build_spec()
+        apply_character_naming(spec_a, "crowd", "Hero000")
+        spec_b = _minimal_crowd_build_spec()
+        apply_character_naming(spec_b, "crowd", "Hero001")
         fake = _fake_with_source_armature("Object_4")   # one source armature, shared
         decomposition = {"source_armature": "Object_4", "character_count": 2,
                          "character_ids": ["Hero000", "Hero001"],
@@ -1950,7 +1952,8 @@ class CrowdBlenderTests(unittest.TestCase):
     def test_build_crowd_in_blender_continues_past_failure(self):
         from asam_human_builder.builder import apply_character_naming
         from asam_human_builder.blender_builder import build_crowd_in_blender
-        spec_ok = apply_character_naming(_minimal_crowd_build_spec(), "crowd", "Hero000")
+        spec_ok = _minimal_crowd_build_spec()
+        apply_character_naming(spec_ok, "crowd", "Hero000")
         bad_spec = {"asset_name": "crowd"}   # missing keys -> raises inside builder
         fake = _fake_with_source_armature("Object_4")
         decomposition = {"source_armature": "Object_4", "character_count": 2,
@@ -1974,7 +1977,8 @@ class CrowdBlenderTests(unittest.TestCase):
                          "shared_bones": [], "unassigned_meshes": []}
 
         def run():
-            spec = apply_character_naming(_minimal_crowd_build_spec(), "crowd", "Hero000")
+            spec = _minimal_crowd_build_spec()
+            apply_character_naming(spec, "crowd", "Hero000")
             return build_crowd_in_blender(
                 "crowd", "ASAM_crowd", [("Hero000", spec)], decomposition, fake,
             )
@@ -2004,7 +2008,8 @@ class CrowdBlenderTests(unittest.TestCase):
         decomposition = {"source_armature": "Object_4", "character_count": 1,
                          "character_ids": ["Hero000"],
                          "shared_bones": [], "unassigned_meshes": []}
-        spec = apply_character_naming(_minimal_crowd_build_spec(), "crowd", "Hero000")
+        spec = _minimal_crowd_build_spec()
+        apply_character_naming(spec, "crowd", "Hero000")
         build_crowd_in_blender(
             "crowd", "ASAM_crowd", [("Hero000", spec)], decomposition, fake,
         )
@@ -2013,7 +2018,8 @@ class CrowdBlenderTests(unittest.TestCase):
         intruder = fake.add_source_mesh("UserMesh", None)
         child.objects.link(intruder)
         # Rebuild must refuse rather than silently delete the foreign object.
-        spec2 = apply_character_naming(_minimal_crowd_build_spec(), "crowd", "Hero000")
+        spec2 = _minimal_crowd_build_spec()
+        apply_character_naming(spec2, "crowd", "Hero000")
         with self.assertRaises(ValueError):
             build_crowd_in_blender(
                 "crowd", "ASAM_crowd", [("Hero000", spec2)], decomposition, fake,


### PR DESCRIPTION
## Summary

Closes #34 — the three **Minor**, refactor-only cleanups deferred from the #33
(builder crowd fan-out) code review. All in `src/asam_human_builder/builder.py`;
**no public-behavior change**.

1. **De-duplicate file loading.** `load_builder_inputs` now delegates path
   resolution + missing-file errors + JSON parsing to `read_builder_inputs`, then
   adds `validate_builder_inputs`. The loading logic lives in one place; the
   flat-shape and crowd (no-validate) callers share it.
2. **Single-purpose `apply_character_naming`.** It previously both mutated `spec`
   in place and returned it. Now it's pure in-place mutation returning `None`,
   matching the sole production caller (which already relied on the mutation and
   ignored the return). Five tests that captured the return value were updated to
   build-then-name.
3. **Drop double validation on the single-character path.**
   `build_character_specs_from_asset_dir` no longer calls `validate_builder_inputs`
   explicitly before `build_armature_spec` (which already validates its inputs).

## Verification

- `python -m unittest discover tests` → **192 tests, OK**.
- `SingleCharacterRegressionTests` (byte-for-byte single-character output guard)
  passes — output unchanged.
- Crowd builder tests exercising `apply_character_naming` pass with the rewritten
  call sites.
- Diff is refactor-only (2 files, +24/-25): no algorithm change;
  `validate_builder_inputs` / `build_armature_spec` bodies untouched.
