### PR TITLE
feat(pipeline): graceful failure on missing prerequisite inputs (#27)

### DIFF
--- a/src/asam_human_builder/main.py
+++ b/src/asam_human_builder/main.py
@@ -37,6 +37,7 @@ from builder import (  # noqa: E402
     write_crowd_builder_report,
 )
 from blender_builder import build_armature_in_blender, build_crowd_in_blender  # noqa: E402
+from pipeline_paths import MissingPrerequisiteError, require_asset_inputs  # noqa: E402
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -61,12 +62,13 @@ def main(argv=None) -> int:
     args = parser.parse_args(argv if argv is not None else _extract_script_argv(sys.argv))
 
     asset_dir = Path(args.asset_dir).resolve() if args.asset_dir else resolve_default_asset_dir(bpy.data.filepath, SCRIPT_DIR)
-    if not asset_dir.exists():
-        raise FileNotFoundError(
-            "Builder input folder does not exist: {0}. Run src/pipeline/main.py or src/phase3_classifier/main.py first.".format(
-                asset_dir
-            )
+    try:
+        require_asset_inputs(
+            asset_dir, ["classifier_report.json", "build_plan.json"], "phase 3 classifier"
         )
+    except MissingPrerequisiteError as err:
+        print("error: {0}".format(err), file=sys.stderr)
+        return 1
 
     print("\n" + "=" * 60)
     print("STARTING ASAM HUMAN BUILDER")

--- a/src/phase3_classifier/main.py
+++ b/src/phase3_classifier/main.py
@@ -15,6 +15,7 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 from phase3_classifier.classifier import print_console_summary, write_asset_report  # noqa: E402
+from pipeline_paths import MissingPrerequisiteError, require_inspector_exports  # noqa: E402
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -33,7 +34,12 @@ def main(argv=None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     asset_dir = Path(args.asset_dir).resolve()
-    classifier_report, build_plan, report_path, plan_path = write_asset_report(asset_dir)
+    try:
+        require_inspector_exports(asset_dir)
+        classifier_report, build_plan, report_path, plan_path = write_asset_report(asset_dir)
+    except MissingPrerequisiteError as err:
+        print("error: {0}".format(err), file=sys.stderr)
+        return 1
     print_console_summary(classifier_report, build_plan, report_path, plan_path)
     return 0
 

--- a/src/pipeline_paths.py
+++ b/src/pipeline_paths.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Sequence
 
 
 ENV_VAR = "OPEN_JAYWALKER_OUTPUT_ROOT"
@@ -41,4 +42,65 @@ def resolve_asset_dir(asset_name: str) -> Path:
     """
     asset_dir = resolve_output_root() / asset_name
     asset_dir.mkdir(parents=True, exist_ok=True)
+    return asset_dir
+
+
+class MissingPrerequisiteError(Exception):
+    """A pipeline stage was run without the prerequisite outputs of the prior stage.
+
+    Raised by the prerequisite checks below so CLI entrypoints can catch it and emit a
+    single-line error + remediation hint (exit code 1) instead of a Python traceback.
+    """
+
+
+def _remediation(asset_dir: Path, produced_by: str) -> str:
+    return "Run the {0} first (e.g. with --asset-dir {1}).".format(produced_by, asset_dir)
+
+
+def require_asset_inputs(
+    asset_dir, required_filenames: Sequence[str], produced_by: str
+) -> Path:
+    """Resolve `asset_dir` and assert each required file is present.
+
+    Raises MissingPrerequisiteError with a one-line message + remediation hint when the
+    directory or any required file is absent; otherwise returns the resolved directory.
+    Used by the builder (classifier_report.json + build_plan.json).
+    """
+    asset_dir = Path(asset_dir).resolve()
+    if not asset_dir.is_dir():
+        raise MissingPrerequisiteError(
+            "Asset directory not found: {0}. {1}".format(
+                asset_dir, _remediation(asset_dir, produced_by)
+            )
+        )
+    missing = [name for name in required_filenames if not (asset_dir / name).exists()]
+    if missing:
+        raise MissingPrerequisiteError(
+            "Missing {0} in {1}. {2}".format(
+                ", ".join(missing), asset_dir, _remediation(asset_dir, produced_by)
+            )
+        )
+    return asset_dir
+
+
+def require_inspector_exports(asset_dir) -> Path:
+    """Classifier prerequisite: `asset_dir` exists and holds >=1 inspector export.
+
+    Inspector exports are named per armature (`<armature>_all.json` /
+    `<armature>_filtered.json`), so this matches by glob rather than a fixed filename.
+    Raises MissingPrerequisiteError (one-line + remediation hint) otherwise.
+    """
+    asset_dir = Path(asset_dir).resolve()
+    if not asset_dir.is_dir():
+        raise MissingPrerequisiteError(
+            "Asset directory not found: {0}. {1}".format(
+                asset_dir, _remediation(asset_dir, "armature inspector")
+            )
+        )
+    if not (list(asset_dir.glob("*_all.json")) or list(asset_dir.glob("*_filtered.json"))):
+        raise MissingPrerequisiteError(
+            "No armature inspector exports (*_all.json) in {0}. {1}".format(
+                asset_dir, _remediation(asset_dir, "armature inspector")
+            )
+        )
     return asset_dir

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -750,6 +750,20 @@ class Phase3ClassifierTests(unittest.TestCase):
         self.assertIn("Recommended primary armature: Armature", result.stdout)
         self.assertIn("Root resolution: reuse_existing_root", result.stdout)
 
+    def test_cli_entrypoint_missing_inputs_fails_cleanly(self):
+        """Empty --asset-dir: exit 1, one-line error + hint, no traceback (#27)."""
+        empty_dir = Path(tempfile.mkdtemp(prefix="phase3_classifier_empty_"))
+        result = subprocess.run(
+            [sys.executable, str(CLI_PATH), "--asset-dir", str(empty_dir)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1, msg=result.stdout + "\n" + result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+        self.assertIn("inspector", result.stderr)
+        self.assertIn("error:", result.stderr)
+
     def test_root_blocker_codes_helper_exists(self):
         from phase3_classifier.classifier import _root_blocker_codes, _root_advisory_codes  # noqa: F401
         self.assertTrue(callable(_root_blocker_codes))

--- a/tests/test_pipeline_paths.py
+++ b/tests/test_pipeline_paths.py
@@ -12,6 +12,9 @@ if str(SRC_ROOT) not in sys.path:
 
 from pipeline_paths import (  # noqa: E402
     ENV_VAR,
+    MissingPrerequisiteError,
+    require_asset_inputs,
+    require_inspector_exports,
     resolve_asset_dir,
     resolve_output_root,
 )
@@ -50,6 +53,68 @@ class PipelinePathsTests(unittest.TestCase):
         os.environ[ENV_VAR] = override
         result = resolve_asset_dir("NewAsset")
         self.assertTrue(result.is_dir())
+
+
+class RequireAssetInputsTests(unittest.TestCase):
+    """Shared prerequisite checks used by the classifier/builder CLI entrypoints (#27)."""
+
+    def _tmp_dir(self) -> Path:
+        return Path(tempfile.mkdtemp(prefix="prereq_test_"))
+
+    def test_returns_resolved_dir_when_all_files_present(self):
+        asset_dir = self._tmp_dir()
+        (asset_dir / "classifier_report.json").write_text("{}", encoding="utf-8")
+        (asset_dir / "build_plan.json").write_text("{}", encoding="utf-8")
+        result = require_asset_inputs(
+            asset_dir, ["classifier_report.json", "build_plan.json"], "phase 3 classifier"
+        )
+        self.assertEqual(result, asset_dir.resolve())
+
+    def test_missing_build_plan_names_the_file_and_gives_hint(self):
+        asset_dir = self._tmp_dir()
+        (asset_dir / "classifier_report.json").write_text("{}", encoding="utf-8")
+        with self.assertRaises(MissingPrerequisiteError) as ctx:
+            require_asset_inputs(
+                asset_dir, ["classifier_report.json", "build_plan.json"], "phase 3 classifier"
+            )
+        message = str(ctx.exception)
+        self.assertIn("build_plan.json", message)
+        self.assertNotIn("classifier_report.json", message)  # present file not listed
+        self.assertIn("--asset-dir", message)  # remediation hint
+        self.assertIn("phase 3 classifier", message)
+
+    def test_nonexistent_dir_reports_directory_not_found(self):
+        missing = self._tmp_dir() / "does_not_exist"
+        with self.assertRaises(MissingPrerequisiteError) as ctx:
+            require_asset_inputs(missing, ["build_plan.json"], "phase 3 classifier")
+        self.assertIn("Asset directory not found", str(ctx.exception))
+
+
+class RequireInspectorExportsTests(unittest.TestCase):
+    def _tmp_dir(self) -> Path:
+        return Path(tempfile.mkdtemp(prefix="prereq_inspector_test_"))
+
+    def test_returns_resolved_dir_when_export_present(self):
+        asset_dir = self._tmp_dir()
+        (asset_dir / "Armature_all.json").write_text("{}", encoding="utf-8")
+        self.assertEqual(require_inspector_exports(asset_dir), asset_dir.resolve())
+
+    def test_accepts_filtered_export(self):
+        asset_dir = self._tmp_dir()
+        (asset_dir / "Armature_filtered.json").write_text("{}", encoding="utf-8")
+        self.assertEqual(require_inspector_exports(asset_dir), asset_dir.resolve())
+
+    def test_empty_dir_raises_with_inspector_hint(self):
+        asset_dir = self._tmp_dir()
+        with self.assertRaises(MissingPrerequisiteError) as ctx:
+            require_inspector_exports(asset_dir)
+        self.assertIn("inspector", str(ctx.exception))
+
+    def test_nonexistent_dir_reports_directory_not_found(self):
+        missing = self._tmp_dir() / "nope"
+        with self.assertRaises(MissingPrerequisiteError) as ctx:
+            require_inspector_exports(missing)
+        self.assertIn("Asset directory not found", str(ctx.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #27. Running a pipeline stage without the previous stage's outputs now produces a
clear one-line error + remediation hint and a nonzero exit code, instead of a raw Python
traceback.

New shared utility in `src/pipeline_paths.py`:
- `MissingPrerequisiteError` — typed exception for absent prerequisites.
- `require_asset_inputs(asset_dir, required_filenames, produced_by)` — used by the builder
  (`classifier_report.json` + `build_plan.json`).
- `require_inspector_exports(asset_dir)` — used by the classifier (>=1 `*_all.json` /
  `*_filtered.json` inspector export).

CLI wiring:
- **Classifier** (`src/phase3_classifier/main.py`): checks for inspector exports, catches
  `MissingPrerequisiteError`, prints `error: ...` to stderr, returns 1.
- **Builder** (`src/asam_human_builder/main.py`): replaces the ad-hoc `asset_dir.exists()`
  check with the shared util + the same catch/print/return-1 pattern.
- **Inspector**: unchanged — it's the first stage with no prerequisite files and already
  degrades gracefully (diagnostics mode) when the scene has no armatures.

Design is additive: the existing deep `FileNotFoundError`/`ValueError` raises remain as a
programmatic backstop, so existing callers/tests are unaffected. Scope is strictly
*missing* prerequisites; corrupt-JSON behavior is unchanged.

## Acceptance criteria

- [x] Each stage prints a one-line error + remediation hint when inputs are missing.
- [x] Nonzero exit code on missing prerequisites.
- [x] Tests cover the builder `build_plan.json`-missing case (via the shared util — the
      builder needs Blender so can't run under unittest) and the classifier missing-input
      case (CLI subprocess: exit 1, clean message, no traceback).

## Verification

- `python -m unittest discover tests` → **200 tests, OK**.
- New `tests/test_pipeline_paths.py` cases for both helpers (missing dir, missing
  `build_plan.json` names the file + hint, glob acceptance).
- New `tests/test_phase3_classifier.py` subprocess test: empty `--asset-dir` → returncode
  1, stderr contains the one-line error + "inspector", and **no** `Traceback`.
