### PR TITLE
feat: add-on panel polish, crowd summary, hide-source, clean button (#46, #47)

### DIFF
--- a/addon/__init__.py
+++ b/addon/__init__.py
@@ -20,13 +20,16 @@ if _ADDON_DIR not in sys.path:
 import bpy
 
 from . import state
+from . import prefs
 from . import operators
 from . import ui
 
 _CLASSES = (
+    prefs.OJAddonPreferences,
     state.OJSettings,
     operators.OJ_OT_run_pipeline,
     operators.OJ_OT_build,
+    operators.OJ_OT_open_output,
     ui.OJ_PT_panel,
 )
 

--- a/addon/__init__.py
+++ b/addon/__init__.py
@@ -30,6 +30,7 @@ _CLASSES = (
     operators.OJ_OT_run_pipeline,
     operators.OJ_OT_build,
     operators.OJ_OT_open_output,
+    operators.OJ_OT_clean,
     ui.OJ_PT_panel,
 )
 

--- a/addon/operators.py
+++ b/addon/operators.py
@@ -1,5 +1,6 @@
-"""Open Jaywalker operators: run the pipeline, then build the ASAM human(s)."""
+"""Open Jaywalker operators: run the pipeline, build, open output folder."""
 
+import os
 from pathlib import Path
 
 import bpy
@@ -12,6 +13,10 @@ from asam_human_builder.build_runner import run_build
 from asam_human_builder.builder import success_message
 
 
+def _addon_prefs(context):
+    return context.preferences.addons[__package__].preferences
+
+
 class OJ_OT_run_pipeline(bpy.types.Operator):
     bl_idname = "open_jaywalker.run_pipeline"
     bl_label = "Run pipeline"
@@ -20,6 +25,11 @@ class OJ_OT_run_pipeline(bpy.types.Operator):
     def execute(self, context):
         settings = context.scene.open_jaywalker
         settings.has_plan = False
+        settings.built = False
+
+        prefs = _addon_prefs(context)
+        if prefs.output_dir:
+            os.environ["OPEN_JAYWALKER_OUTPUT_ROOT"] = bpy.path.abspath(prefs.output_dir)
 
         purge_previous_generated_artifacts(bpy)
 
@@ -37,6 +47,8 @@ class OJ_OT_run_pipeline(bpy.types.Operator):
         settings.mapped = summary["mapped"]
         settings.total = summary["total"]
         settings.missing_csv = ", ".join(summary["missing_targets"])
+        settings.review_flags_csv = ", ".join(summary["review_flags"])
+        settings.character_ids_csv = ", ".join(summary["character_ids"])
         settings.is_crowd = summary["is_crowd"]
         settings.character_count = summary["character_count"]
         settings.has_plan = True
@@ -57,17 +69,35 @@ class OJ_OT_build(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return bool(context.scene.open_jaywalker.has_plan)
+        s = context.scene.open_jaywalker
+        return bool(s.has_plan) and not s.built
 
     def execute(self, context):
         settings = context.scene.open_jaywalker
         asset_dir = Path(settings.asset_dir)
+        context.window.cursor_set('WAIT')
         try:
             report = run_build(asset_dir, bpy)
         except Exception as exc:  # surface as an operator error, never crash
             self.report({'ERROR'}, "Build failed: {0}".format(exc))
             return {'CANCELLED'}
+        finally:
+            context.window.cursor_set('DEFAULT')
         report_path = asset_dir / "builder_report.json"
         self.report({'INFO'}, success_message(report, report_path))
-        settings.has_plan = False
+        settings.built = True
+        return {'FINISHED'}
+
+
+class OJ_OT_open_output(bpy.types.Operator):
+    bl_idname = "open_jaywalker.open_output"
+    bl_label = "Open output folder"
+    bl_description = "Open the asset output folder in the system file browser"
+
+    @classmethod
+    def poll(cls, context):
+        return bool(context.scene.open_jaywalker.asset_dir)
+
+    def execute(self, context):
+        bpy.ops.wm.path_open(filepath=context.scene.open_jaywalker.asset_dir)
         return {'FINISHED'}

--- a/addon/operators.py
+++ b/addon/operators.py
@@ -47,6 +47,9 @@ class OJ_OT_run_pipeline(bpy.types.Operator):
         settings.mapped = summary["mapped"]
         settings.total = summary["total"]
         settings.missing_csv = ", ".join(summary["missing_targets"])
+        settings.missing_by_target_csv = ", ".join(
+            "{0} x{1}".format(entry["target"], entry["count"]) for entry in summary["missing_by_target"]
+        )
         settings.review_flags_csv = ", ".join(summary["review_flags"])
         settings.character_ids_csv = ", ".join(summary["character_ids"])
         settings.is_crowd = summary["is_crowd"]

--- a/addon/operators.py
+++ b/addon/operators.py
@@ -104,3 +104,15 @@ class OJ_OT_open_output(bpy.types.Operator):
     def execute(self, context):
         bpy.ops.wm.path_open(filepath=context.scene.open_jaywalker.asset_dir)
         return {'FINISHED'}
+
+
+class OJ_OT_clean(bpy.types.Operator):
+    bl_idname = "open_jaywalker.clean"
+    bl_label = "Clean generated rigs"
+    bl_description = "Remove all previously-generated ASAM rigs/collections from the scene (source is left untouched)"
+
+    def execute(self, context):
+        removed = purge_previous_generated_artifacts(bpy)
+        context.scene.open_jaywalker.built = False
+        self.report({'INFO'}, "Removed {0} generated object(s)/collection(s).".format(removed))
+        return {'FINISHED'}

--- a/addon/prefs.py
+++ b/addon/prefs.py
@@ -1,0 +1,22 @@
+"""Add-on preferences: override the pipeline output root."""
+
+import bpy
+
+
+class OJAddonPreferences(bpy.types.AddonPreferences):
+    bl_idname = __package__
+
+    output_dir: bpy.props.StringProperty(
+        name="Output directory",
+        description="Override the pipeline output root (sets OPEN_JAYWALKER_OUTPUT_ROOT). Leave blank for the default.",
+        subtype='DIR_PATH',
+        default="",
+    )
+
+    def draw(self, context):
+        layout = self.layout
+        layout.prop(self, "output_dir")
+        layout.label(
+            text="Blank = default <repo>/output (or an existing OPEN_JAYWALKER_OUTPUT_ROOT).",
+            icon='INFO',
+        )

--- a/addon/state.py
+++ b/addon/state.py
@@ -5,10 +5,14 @@ import bpy
 
 class OJSettings(bpy.types.PropertyGroup):
     has_plan: bpy.props.BoolProperty(default=False)
+    built: bpy.props.BoolProperty(default=False)
+    show_details: bpy.props.BoolProperty(default=False)
     asset_dir: bpy.props.StringProperty(default="")
     recommended_armature: bpy.props.StringProperty(default="")
     mapped: bpy.props.IntProperty(default=0)
     total: bpy.props.IntProperty(default=28)
     missing_csv: bpy.props.StringProperty(default="")
+    review_flags_csv: bpy.props.StringProperty(default="")
+    character_ids_csv: bpy.props.StringProperty(default="")
     is_crowd: bpy.props.BoolProperty(default=False)
     character_count: bpy.props.IntProperty(default=0)

--- a/addon/state.py
+++ b/addon/state.py
@@ -12,6 +12,7 @@ class OJSettings(bpy.types.PropertyGroup):
     mapped: bpy.props.IntProperty(default=0)
     total: bpy.props.IntProperty(default=28)
     missing_csv: bpy.props.StringProperty(default="")
+    missing_by_target_csv: bpy.props.StringProperty(default="")
     review_flags_csv: bpy.props.StringProperty(default="")
     character_ids_csv: bpy.props.StringProperty(default="")
     is_crowd: bpy.props.BoolProperty(default=False)

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -1,4 +1,4 @@
-"""Open Jaywalker N-panel: Run pipeline -> plan summary -> Build."""
+"""Open Jaywalker N-panel: status, plan summary (collapsible), build, output."""
 
 import bpy
 
@@ -12,22 +12,62 @@ class OJ_PT_panel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        settings = context.scene.open_jaywalker
+        s = context.scene.open_jaywalker
+
+        if s.built:
+            status, icon = "Built", 'CHECKMARK'
+        elif s.has_plan:
+            status, icon = "Plan ready", 'INFO'
+        else:
+            status, icon = "Idle", 'RADIOBUT_OFF'
+        layout.label(text="Status: {0}".format(status), icon=icon)
 
         layout.operator("open_jaywalker.run_pipeline", icon='PLAY')
 
-        if not settings.has_plan:
-            layout.label(text="Run the pipeline to generate a plan.")
-            return
+        if s.has_plan:
+            layout.separator()
+            box = layout.box()
+            box.label(text="Plan", icon='PRESET')
+            col = box.column(align=True)
+            col.label(text="Primary rig: {0}".format(s.recommended_armature))
+            mapped_row = col.row()
+            mapped_row.alert = s.mapped < s.total
+            mapped_row.label(
+                text="Mapped: {0}/{1}".format(s.mapped, s.total),
+                icon=('ERROR' if s.mapped < s.total else 'CHECKMARK'),
+            )
+            if s.is_crowd:
+                col.label(text="Crowd: {0} characters".format(s.character_count))
 
-        box = layout.box()
-        box.label(text="Plan ready", icon='CHECKMARK')
-        box.label(text="Primary: {0}".format(settings.recommended_armature))
-        box.label(text="Mapped: {0}/{1}".format(settings.mapped, settings.total))
-        if settings.is_crowd:
-            box.label(text="Crowd: {0} characters".format(settings.character_count))
-        if settings.missing_csv:
-            box.label(text="Missing targets:")
-            for name in settings.missing_csv.split(", "):
-                box.label(text="   - {0}".format(name))
-        layout.operator("open_jaywalker.build", icon='MOD_ARMATURE')
+            box.prop(
+                s, "show_details",
+                text="Details",
+                icon=('TRIA_DOWN' if s.show_details else 'TRIA_RIGHT'),
+                emboss=False,
+            )
+            if s.show_details:
+                det = box.box()
+                if s.missing_csv:
+                    det.label(text="Missing targets:")
+                    for name in s.missing_csv.split(", "):
+                        det.label(text="   - {0}".format(name))
+                if s.review_flags_csv:
+                    det.label(text="Review flags:")
+                    for flag in s.review_flags_csv.split(", "):
+                        det.label(text="   - {0}".format(flag))
+                if s.is_crowd and s.character_ids_csv:
+                    det.label(text="Characters:")
+                    for cid in s.character_ids_csv.split(", "):
+                        det.label(text="   - {0}".format(cid))
+
+            build_row = layout.row()
+            build_row.enabled = s.has_plan and not s.built
+            build_row.operator("open_jaywalker.build", icon='MOD_ARMATURE')
+
+        if s.asset_dir:
+            layout.separator()
+            layout.label(text="Output:")
+            layout.label(text=s.asset_dir)
+            layout.operator("open_jaywalker.open_output", icon='FILE_FOLDER')
+        elif not s.has_plan:
+            layout.label(text="Run the pipeline to generate a plan.")

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -47,7 +47,11 @@ class OJ_PT_panel(bpy.types.Panel):
             )
             if s.show_details:
                 det = box.box()
-                if s.missing_csv:
+                if s.is_crowd and s.missing_by_target_csv:
+                    det.label(text="Missing across {0} characters:".format(s.character_count))
+                    for entry in s.missing_by_target_csv.split(", "):
+                        det.label(text="   - {0}".format(entry))
+                elif not s.is_crowd and s.missing_csv:
                     det.label(text="Missing targets:")
                     for name in s.missing_csv.split(", "):
                         det.label(text="   - {0}".format(name))
@@ -59,7 +63,7 @@ class OJ_PT_panel(bpy.types.Panel):
                     det.label(text="Characters:")
                     for cid in s.character_ids_csv.split(", "):
                         det.label(text="   - {0}".format(cid))
-                if not s.missing_csv and not s.review_flags_csv:
+                if not s.missing_csv and not s.missing_by_target_csv and not s.review_flags_csv:
                     det.label(
                         text="All {0} core targets mapped; no review flags.".format(s.total),
                         icon='CHECKMARK',

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -80,3 +80,6 @@ class OJ_PT_panel(bpy.types.Panel):
             layout.operator("open_jaywalker.open_output", icon='FILE_FOLDER')
         elif not s.has_plan:
             layout.label(text="Run the pipeline to generate a plan.")
+
+        layout.separator()
+        layout.operator("open_jaywalker.clean", icon='TRASH')

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -59,6 +59,11 @@ class OJ_PT_panel(bpy.types.Panel):
                     det.label(text="Characters:")
                     for cid in s.character_ids_csv.split(", "):
                         det.label(text="   - {0}".format(cid))
+                if not s.missing_csv and not s.review_flags_csv:
+                    det.label(
+                        text="All {0} core targets mapped; no review flags.".format(s.total),
+                        icon='CHECKMARK',
+                    )
 
             build_row = layout.row()
             build_row.enabled = s.has_plan and not s.built

--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -297,6 +297,8 @@ def _create_armature_object(bpy_module, armature_name: str, asset_name: str, col
     armature_object.parent = group_root
     armature_object[GENERATED_MARKER_KEY] = True
     armature_object[GENERATED_ASSET_KEY] = asset_name
+    # Draw the generated rig in front of the mesh so the bones are visible.
+    armature_object.show_in_front = True
     collection.objects.link(armature_object)
     return armature_object
 

--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -101,6 +101,8 @@ def build_armature_in_blender(build_spec: dict, bpy_module=None, parent_collecti
         character_prefix,
     )
 
+    hidden_source_objects = _hide_source_objects(bpy_module, source_armature, build_spec)
+
     return {
         "generated_collection_name": collection.name,
         "group_root_name": group_root.name,
@@ -109,7 +111,28 @@ def build_armature_in_blender(build_spec: dict, bpy_module=None, parent_collecti
         "duplicated_meshes": mesh_result["duplicated_meshes"],
         "skipped_meshes": mesh_result["skipped_meshes"],
         "mesh_warnings": mesh_result["mesh_warnings"],
+        "hidden_source_objects": hidden_source_objects,
     }
+
+
+def _hide_source_objects(bpy_module, source_armature, build_spec) -> List[str]:
+    """Hide the source rig + its bound meshes so the generated ASAM result is what shows.
+
+    Reversible (the viewport 'eye'); the build duplicates meshes first, so the
+    originals are only hidden, never altered. Returns the hidden object names.
+    """
+    hidden: List[str] = []
+    targets = []
+    if source_armature is not None:
+        targets.append(source_armature)
+    for record in build_spec.get("mesh_binding", {}).get("meshes", []):
+        mesh = bpy_module.data.objects.get(record.get("mesh_name"))
+        if mesh is not None and mesh not in targets:
+            targets.append(mesh)
+    for obj in targets:
+        obj.hide_set(True)
+        hidden.append(obj.name)
+    return hidden
 
 
 def purge_previous_generated_artifacts(bpy_module) -> int:

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -552,6 +552,7 @@ def build_builder_report(build_spec: dict, execution_result: dict) -> dict:
         "targets_created_heuristically": created_targets,
         "preserved_extras_count": len(build_spec.get("extras_preserved", [])),
         "preserved_pelvis_pair": copy.deepcopy(build_spec.get("preserved_pelvis_pair", [])),
+        "hidden_source_objects": list(execution_result.get("hidden_source_objects", [])),
         "warnings": list(build_spec.get("warnings", [])),
     }
 

--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -554,6 +554,18 @@ def print_console_summary(report: dict, plan: dict, report_path: Path, plan_path
     print("Recommended primary armature: {0}".format(report["recommended_primary_armature"]))
     print("Root resolution: {0}".format(plan["root_resolutions"][0]["mode"]))
     print("Missing targets: {0}".format(", ".join(report["missing_targets"]) or "(none)"))
+    crowd_characters = report.get("characters") or []
+    if crowd_characters:
+        missing_counts = {}
+        for character in crowd_characters:
+            for target in character.get("missing_targets", []):
+                missing_counts[target] = missing_counts.get(target, 0) + 1
+        print("Crowd missing-target counts (of {0} characters):".format(len(crowd_characters)))
+        if missing_counts:
+            for target, count in sorted(missing_counts.items(), key=lambda item: (-item[1], item[0])):
+                print("  {0}: {1}".format(target, count))
+        else:
+            print("  (none)")
     print("Ambiguous targets: {0}".format(", ".join(item["target"] for item in report["ambiguous_targets"]) or "(none)"))
     print("Preserved extras count: {0}".format(len(plan["extras_preserved"])))
     print("Report written to: {0}".format(report_path))

--- a/src/pipeline/plan_summary.py
+++ b/src/pipeline/plan_summary.py
@@ -9,6 +9,18 @@ from __future__ import annotations
 from phase3_classifier.classifier import CORE_TARGETS
 
 
+def _aggregate_missing_by_target(report_characters: list) -> list:
+    """Count, per target, how many crowd characters are missing it (desc by count)."""
+    counts = {}
+    for character in report_characters:
+        for target in character.get("missing_targets", []):
+            counts[target] = counts.get(target, 0) + 1
+    return [
+        {"target": target, "count": count}
+        for target, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
 def summarize_plan(classifier_report: dict, build_plan: dict) -> dict:
     """Summarize a classifier report + build plan for display.
 
@@ -18,7 +30,9 @@ def summarize_plan(classifier_report: dict, build_plan: dict) -> dict:
     total = len(CORE_TARGETS)
     missing = list(classifier_report.get("missing_targets", []))
     characters = build_plan.get("characters") or []
+    missing_by_target = _aggregate_missing_by_target(classifier_report.get("characters") or [])
     return {
+        "missing_by_target": missing_by_target,
         "recommended_armature": classifier_report.get("recommended_primary_armature", ""),
         "total": total,
         "mapped": total - len(missing),

--- a/src/pipeline/plan_summary.py
+++ b/src/pipeline/plan_summary.py
@@ -25,4 +25,6 @@ def summarize_plan(classifier_report: dict, build_plan: dict) -> dict:
         "missing_targets": missing,
         "is_crowd": bool(characters),
         "character_count": len(characters),
+        "review_flags": list(classifier_report.get("review_flags", [])),
+        "character_ids": [c.get("character_id", "") for c in characters],
     }

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -303,6 +303,7 @@ class _FakeObject(_FakeProps):
         self.mode = "OBJECT"
         self.selected = False
         self.show_in_front = False
+        self._hidden = False
         self.empty_display_type = None
         self.modifiers = []
         self.vertex_groups = []
@@ -331,6 +332,12 @@ class _FakeObject(_FakeProps):
 
     def select_set(self, value: bool):
         self.selected = bool(value)
+
+    def hide_set(self, value: bool):
+        self._hidden = bool(value)
+
+    def hide_get(self):
+        return self._hidden
 
 
 class _FakeObjectStore:
@@ -605,6 +612,27 @@ class AsamHumanBuilderTests(unittest.TestCase):
         armature_obj = bpy_module.data.objects.get(build_spec["generated_armature_name"])
         self.assertIsNotNone(armature_obj)
         self.assertTrue(armature_obj.show_in_front)
+
+    def test_build_hides_source_rig_and_meshes(self):
+        """After a build, the source armature + its bound meshes are hidden (reversible)."""
+        asset_dir = _copy_asset_folder("openmatexamplehuman")
+        write_asset_report(asset_dir)
+        _, build_plan, build_spec = build_armature_spec_from_asset_dir(asset_dir)
+        bpy_module = _FakeBpy()
+        bpy_module.add_source_armature("Armature")
+        for mesh_record in build_plan["mesh_binding"]["meshes"]:
+            bpy_module.add_source_mesh(
+                mesh_record["mesh_name"],
+                bpy_module.data.objects.get("Armature"),
+            )
+        execution_result = build_armature_in_blender(build_spec, bpy_module)
+
+        self.assertTrue(bpy_module.data.objects.get("Armature").hide_get())
+        for mesh_record in build_plan["mesh_binding"]["meshes"]:
+            self.assertTrue(bpy_module.data.objects.get(mesh_record["mesh_name"]).hide_get())
+        self.assertIn("Armature", execution_result["hidden_source_objects"])
+        report = build_builder_report(build_spec, execution_result)
+        self.assertIn("Armature", report["hidden_source_objects"])
 
     def test_grp_root_location_set_to_bbox_ground_center(self):
         """Grp_Root empty's location must equal the source-frame bbox_ground_center."""

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -302,6 +302,7 @@ class _FakeObject(_FakeProps):
         self.parent = None
         self.mode = "OBJECT"
         self.selected = False
+        self.show_in_front = False
         self.empty_display_type = None
         self.modifiers = []
         self.vertex_groups = []
@@ -587,6 +588,23 @@ class AsamHumanBuilderTests(unittest.TestCase):
         )
         self.assertEqual(report["root_mode"], "reuse_existing_root")
         self.assertIsNone(report["preserved_source_root"])
+
+    def test_generated_armature_is_shown_in_front(self):
+        """The generated armature object enables 'In Front' so bones draw over the mesh."""
+        asset_dir = _copy_asset_folder("openmatexamplehuman")
+        write_asset_report(asset_dir)
+        _, build_plan, build_spec = build_armature_spec_from_asset_dir(asset_dir)
+        bpy_module = _FakeBpy()
+        bpy_module.add_source_armature("Armature")
+        for mesh_record in build_plan["mesh_binding"]["meshes"]:
+            bpy_module.add_source_mesh(
+                mesh_record["mesh_name"],
+                bpy_module.data.objects.get("Armature"),
+            )
+        build_armature_in_blender(build_spec, bpy_module)
+        armature_obj = bpy_module.data.objects.get(build_spec["generated_armature_name"])
+        self.assertIsNotNone(armature_obj)
+        self.assertTrue(armature_obj.show_in_front)
 
     def test_grp_root_location_set_to_bbox_ground_center(self):
         """Grp_Root empty's location must equal the source-frame bbox_ground_center."""

--- a/tests/test_plan_summary.py
+++ b/tests/test_plan_summary.py
@@ -31,6 +31,27 @@ class SummarizePlanTests(unittest.TestCase):
         self.assertEqual(summary["character_count"], 0)
         self.assertEqual(summary["review_flags"], ["multiple_roots", "root_noncompliant"])
         self.assertEqual(summary["character_ids"], [])
+        self.assertEqual(summary["missing_by_target"], [])
+
+    def test_crowd_missing_by_target_aggregates(self):
+        report = {
+            "recommended_primary_armature": "_rootJoint",
+            "missing_targets": [],
+            "review_flags": [],
+            "characters": [
+                {"character_id": "c0", "missing_targets": ["Eye_Left", "Lower_Spine"]},
+                {"character_id": "c1", "missing_targets": ["Eye_Left"]},
+                {"character_id": "c2", "missing_targets": ["Eye_Left", "Lower_Spine"]},
+            ],
+        }
+        plan = {"characters": [{"character_id": "c0"}, {"character_id": "c1"}, {"character_id": "c2"}]}
+        summary = summarize_plan(report, plan)
+        self.assertTrue(summary["is_crowd"])
+        self.assertEqual(summary["character_count"], 3)
+        self.assertEqual(
+            summary["missing_by_target"],
+            [{"target": "Eye_Left", "count": 3}, {"target": "Lower_Spine", "count": 2}],
+        )
 
     def test_crowd_summary_uses_character_count(self):
         report, _plan = self._load()

--- a/tests/test_plan_summary.py
+++ b/tests/test_plan_summary.py
@@ -29,6 +29,8 @@ class SummarizePlanTests(unittest.TestCase):
         self.assertIn("Eye_Left", summary["missing_targets"])
         self.assertFalse(summary["is_crowd"])
         self.assertEqual(summary["character_count"], 0)
+        self.assertEqual(summary["review_flags"], ["multiple_roots", "root_noncompliant"])
+        self.assertEqual(summary["character_ids"], [])
 
     def test_crowd_summary_uses_character_count(self):
         report, _plan = self._load()
@@ -36,6 +38,7 @@ class SummarizePlanTests(unittest.TestCase):
         summary = summarize_plan(report, crowd_plan)
         self.assertTrue(summary["is_crowd"])
         self.assertEqual(summary["character_count"], 2)
+        self.assertEqual(summary["character_ids"], ["c0", "c1"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add-on panel UX polish plus a couple of generated-rig usability fixes.

## #46 — Add-on panel polish + crowd summary
- Status line (Idle → Plan ready → Built ✓), button enable/disable, alert-tinted Mapped row.
- Collapsible **Details**: missing targets, review flags, crowd character names; an "all core targets mapped" note when clean.
- **Crowd-aware missing summary**: `summarize_plan` now returns `missing_by_target`; the panel (and `print_console_summary`) show per-target counts across the crowd (e.g. `Eye_Left ×66`) instead of one lumped list.
- Output path + **Open output folder** button; add-on **Preferences** with an output-dir override (sets `OPEN_JAYWALKER_OUTPUT_ROOT`).
- **In Front** enabled on the generated armature so bones draw over the mesh.
- **Clean generated rigs** button → one-click purge of all generated rigs/collections (single + crowd), source untouched.

## #47 — Hide source after build (reversible)
- After a build, the source rig + bound meshes are hidden (`hide_set`, reversible via the eye) so the viewport shows just the ASAM result. Single + crowd. Recorded as `hidden_source_objects` in `builder_report`.

## Test plan
- `python -m unittest discover tests` → 258 passing (new: crowd aggregation, In-Front, hide-source).
- bpy glue (panel/operators/prefs) verified by `py_compile`.
- Manual: built `dist/open_jaywalker-0.1.0.zip`, installed in Blender; verified panel, crowd summary on 1000idles, build hides source, Clean button purges, Open-folder works.
- Single-character output byte-for-byte unchanged.

Closes #46
Closes #47
