### PR TITLE
Crowd build: canonical metres + body-anchored placement (#49); add-on auto-updater (#50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ dmypy.json
 # Pipeline runtime outputs. Inspector + classifier + builder write here by
 # default; redirected via OPEN_JAYWALKER_OUTPUT_ROOT for tests and runbooks.
 /output/
+
+# Add-on auto-updater runtime state (created in the installed add-on at runtime).
+addon/open_jaywalker_updater/

--- a/addon/__init__.py
+++ b/addon/__init__.py
@@ -13,9 +13,15 @@ import sys
 
 # When installed, the bundled pipeline packages sit beside this file. Put our own
 # directory on sys.path so their absolute imports (phase3_classifier.*, etc.) resolve.
-_ADDON_DIR = os.path.dirname(os.path.abspath(__file__))
+# Resolve symlinks so local dev setup finds the actual repo path
+_ADDON_DIR = os.path.dirname(os.path.realpath(__file__))
 if _ADDON_DIR not in sys.path:
     sys.path.append(_ADDON_DIR)
+
+# For local development via symlink, src/ is outside addon/
+_SRC_DIR = os.path.join(os.path.dirname(_ADDON_DIR), "src")
+if os.path.exists(_SRC_DIR) and _SRC_DIR not in sys.path:
+    sys.path.append(_SRC_DIR)
 
 import bpy
 
@@ -23,6 +29,7 @@ from . import state
 from . import prefs
 from . import operators
 from . import ui
+from . import addon_updater_ops
 
 _CLASSES = (
     prefs.OJAddonPreferences,
@@ -36,12 +43,18 @@ _CLASSES = (
 
 
 def register():
+    updater = addon_updater_ops.updater
+    updater.user = "roboticrustacean"
+    updater.repo = "open-jaywalker"
+    addon_updater_ops.register(bl_info)
+
     for cls in _CLASSES:
         bpy.utils.register_class(cls)
     bpy.types.Scene.open_jaywalker = bpy.props.PointerProperty(type=state.OJSettings)
 
 
 def unregister():
+    addon_updater_ops.unregister()
     del bpy.types.Scene.open_jaywalker
     for cls in reversed(_CLASSES):
         bpy.utils.unregister_class(cls)

--- a/addon/addon_updater.py
+++ b/addon/addon_updater.py
@@ -1,0 +1,1744 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+
+"""
+See documentation for usage
+https://github.com/CGCookie/blender-addon-updater
+"""
+
+__version__ = "1.1.1"
+
+import errno
+import traceback
+import platform
+import ssl
+import urllib.request
+import urllib
+import os
+import json
+import zipfile
+import shutil
+import threading
+import fnmatch
+from datetime import datetime, timedelta
+
+# Blender imports, used in limited cases.
+import bpy
+import addon_utils
+
+# -----------------------------------------------------------------------------
+# The main class
+# -----------------------------------------------------------------------------
+
+
+class SingletonUpdater:
+    """Addon updater service class.
+
+    This is the singleton class to instance once and then reference where
+    needed throughout the addon. It implements all the interfaces for running
+    updates.
+    """
+    def __init__(self):
+
+        self._engine = GithubEngine()
+        self._user = None
+        self._repo = None
+        self._website = None
+        self._current_version = None
+        self._subfolder_path = None
+        self._tags = list()
+        self._tag_latest = None
+        self._tag_names = list()
+        self._latest_release = None
+        self._use_releases = False
+        self._include_branches = False
+        self._include_branch_list = ['master']
+        self._include_branch_auto_check = False
+        self._manual_only = False
+        self._version_min_update = None
+        self._version_max_update = None
+
+        # By default, backup current addon on update/target install.
+        self._backup_current = True
+        self._backup_ignore_patterns = None
+
+        # Set patterns the files to overwrite during an update.
+        self._overwrite_patterns = ["*.py", "*.pyc"]
+        self._remove_pre_update_patterns = list()
+
+        # By default, don't auto disable+re-enable the addon after an update,
+        # as this is less stable/often won't fully reload all modules anyways.
+        self._auto_reload_post_update = False
+
+        # Settings for the frequency of automated background checks.
+        self._check_interval_enabled = False
+        self._check_interval_months = 0
+        self._check_interval_days = 7
+        self._check_interval_hours = 0
+        self._check_interval_minutes = 0
+
+        # runtime variables, initial conditions
+        self._verbose = False
+        self._use_print_traces = True
+        self._fake_install = False
+        self._async_checking = False  # only true when async daemon started
+        self._update_ready = None
+        self._update_link = None
+        self._update_version = None
+        self._source_zip = None
+        self._check_thread = None
+        self._select_link = None
+        self.skip_tag = None
+
+        # Get data from the running blender module (addon).
+        self._addon = __package__.lower()
+        self._addon_package = __package__  # Must not change.
+        self._updater_path = os.path.join(
+            os.path.dirname(__file__), self._addon + "_updater")
+        self._addon_root = os.path.dirname(__file__)
+        self._json = dict()
+        self._error = None
+        self._error_msg = None
+        self._prefiltered_tag_count = 0
+
+        # UI properties, not used within this module but still useful to have.
+
+        # to verify a valid import, in place of placeholder import
+        self.show_popups = True  # UI uses to show popups or not.
+        self.invalid_updater = False
+
+        # pre-assign basic select-link function
+        def select_link_function(self, tag):
+            return tag["zipball_url"]
+
+        self._select_link = select_link_function
+
+    def print_trace(self):
+        """Print handled exception details when use_print_traces is set"""
+        if self._use_print_traces:
+            traceback.print_exc()
+
+    def print_verbose(self, msg):
+        """Print out a verbose logging message if verbose is true."""
+        if not self._verbose:
+            return
+        print("{} addon: ".format(self.addon) + msg)
+
+    # -------------------------------------------------------------------------
+    # Getters and setters
+    # -------------------------------------------------------------------------
+    @property
+    def addon(self):
+        return self._addon
+
+    @addon.setter
+    def addon(self, value):
+        self._addon = str(value)
+
+    @property
+    def api_url(self):
+        return self._engine.api_url
+
+    @api_url.setter
+    def api_url(self, value):
+        if not self.check_is_url(value):
+            raise ValueError("Not a valid URL: " + value)
+        self._engine.api_url = value
+
+    @property
+    def async_checking(self):
+        return self._async_checking
+
+    @property
+    def auto_reload_post_update(self):
+        return self._auto_reload_post_update
+
+    @auto_reload_post_update.setter
+    def auto_reload_post_update(self, value):
+        try:
+            self._auto_reload_post_update = bool(value)
+        except:
+            raise ValueError("auto_reload_post_update must be a boolean value")
+
+    @property
+    def backup_current(self):
+        return self._backup_current
+
+    @backup_current.setter
+    def backup_current(self, value):
+        if value is None:
+            self._backup_current = False
+        else:
+            self._backup_current = value
+
+    @property
+    def backup_ignore_patterns(self):
+        return self._backup_ignore_patterns
+
+    @backup_ignore_patterns.setter
+    def backup_ignore_patterns(self, value):
+        if value is None:
+            self._backup_ignore_patterns = None
+        elif not isinstance(value, list):
+            raise ValueError("Backup pattern must be in list format")
+        else:
+            self._backup_ignore_patterns = value
+
+    @property
+    def check_interval(self):
+        return (self._check_interval_enabled,
+                self._check_interval_months,
+                self._check_interval_days,
+                self._check_interval_hours,
+                self._check_interval_minutes)
+
+    @property
+    def current_version(self):
+        return self._current_version
+
+    @current_version.setter
+    def current_version(self, tuple_values):
+        if tuple_values is None:
+            self._current_version = None
+            return
+        elif type(tuple_values) is not tuple:
+            try:
+                tuple(tuple_values)
+            except:
+                raise ValueError(
+                    "current_version must be a tuple of integers")
+        for i in tuple_values:
+            if type(i) is not int:
+                raise ValueError(
+                    "current_version must be a tuple of integers")
+        self._current_version = tuple(tuple_values)
+
+    @property
+    def engine(self):
+        return self._engine.name
+
+    @engine.setter
+    def engine(self, value):
+        engine = value.lower()
+        if engine == "github":
+            self._engine = GithubEngine()
+        elif engine == "gitlab":
+            self._engine = GitlabEngine()
+        elif engine == "bitbucket":
+            self._engine = BitbucketEngine()
+        else:
+            raise ValueError("Invalid engine selection")
+
+    @property
+    def error(self):
+        return self._error
+
+    @property
+    def error_msg(self):
+        return self._error_msg
+
+    @property
+    def fake_install(self):
+        return self._fake_install
+
+    @fake_install.setter
+    def fake_install(self, value):
+        if not isinstance(value, bool):
+            raise ValueError("fake_install must be a boolean value")
+        self._fake_install = bool(value)
+
+    # not currently used
+    @property
+    def include_branch_auto_check(self):
+        return self._include_branch_auto_check
+
+    @include_branch_auto_check.setter
+    def include_branch_auto_check(self, value):
+        try:
+            self._include_branch_auto_check = bool(value)
+        except:
+            raise ValueError("include_branch_autocheck must be a boolean")
+
+    @property
+    def include_branch_list(self):
+        return self._include_branch_list
+
+    @include_branch_list.setter
+    def include_branch_list(self, value):
+        try:
+            if value is None:
+                self._include_branch_list = ['master']
+            elif not isinstance(value, list) or len(value) == 0:
+                raise ValueError(
+                    "include_branch_list should be a list of valid branches")
+            else:
+                self._include_branch_list = value
+        except:
+            raise ValueError(
+                "include_branch_list should be a list of valid branches")
+
+    @property
+    def include_branches(self):
+        return self._include_branches
+
+    @include_branches.setter
+    def include_branches(self, value):
+        try:
+            self._include_branches = bool(value)
+        except:
+            raise ValueError("include_branches must be a boolean value")
+
+    @property
+    def json(self):
+        if len(self._json) == 0:
+            self.set_updater_json()
+        return self._json
+
+    @property
+    def latest_release(self):
+        if self._latest_release is None:
+            return None
+        return self._latest_release
+
+    @property
+    def manual_only(self):
+        return self._manual_only
+
+    @manual_only.setter
+    def manual_only(self, value):
+        try:
+            self._manual_only = bool(value)
+        except:
+            raise ValueError("manual_only must be a boolean value")
+
+    @property
+    def overwrite_patterns(self):
+        return self._overwrite_patterns
+
+    @overwrite_patterns.setter
+    def overwrite_patterns(self, value):
+        if value is None:
+            self._overwrite_patterns = ["*.py", "*.pyc"]
+        elif not isinstance(value, list):
+            raise ValueError("overwrite_patterns needs to be in a list format")
+        else:
+            self._overwrite_patterns = value
+
+    @property
+    def private_token(self):
+        return self._engine.token
+
+    @private_token.setter
+    def private_token(self, value):
+        if value is None:
+            self._engine.token = None
+        else:
+            self._engine.token = str(value)
+
+    @property
+    def remove_pre_update_patterns(self):
+        return self._remove_pre_update_patterns
+
+    @remove_pre_update_patterns.setter
+    def remove_pre_update_patterns(self, value):
+        if value is None:
+            self._remove_pre_update_patterns = list()
+        elif not isinstance(value, list):
+            raise ValueError(
+                "remove_pre_update_patterns needs to be in a list format")
+        else:
+            self._remove_pre_update_patterns = value
+
+    @property
+    def repo(self):
+        return self._repo
+
+    @repo.setter
+    def repo(self, value):
+        try:
+            self._repo = str(value)
+        except:
+            raise ValueError("repo must be a string value")
+
+    @property
+    def select_link(self):
+        return self._select_link
+
+    @select_link.setter
+    def select_link(self, value):
+        # ensure it is a function assignment, with signature:
+        # input self, tag; returns link name
+        if not hasattr(value, "__call__"):
+            raise ValueError("select_link must be a function")
+        self._select_link = value
+
+    @property
+    def stage_path(self):
+        return self._updater_path
+
+    @stage_path.setter
+    def stage_path(self, value):
+        if value is None:
+            self.print_verbose("Aborting assigning stage_path, it's null")
+            return
+        elif value is not None and not os.path.exists(value):
+            try:
+                os.makedirs(value)
+            except:
+                self.print_verbose("Error trying to staging path")
+                self.print_trace()
+                return
+        self._updater_path = value
+
+    @property
+    def subfolder_path(self):
+        return self._subfolder_path
+
+    @subfolder_path.setter
+    def subfolder_path(self, value):
+        self._subfolder_path = value
+
+    @property
+    def tags(self):
+        if len(self._tags) == 0:
+            return list()
+        tag_names = list()
+        for tag in self._tags:
+            tag_names.append(tag["name"])
+        return tag_names
+
+    @property
+    def tag_latest(self):
+        if self._tag_latest is None:
+            return None
+        return self._tag_latest["name"]
+
+    @property
+    def update_link(self):
+        return self._update_link
+
+    @property
+    def update_ready(self):
+        return self._update_ready
+
+    @property
+    def update_version(self):
+        return self._update_version
+
+    @property
+    def use_releases(self):
+        return self._use_releases
+
+    @use_releases.setter
+    def use_releases(self, value):
+        try:
+            self._use_releases = bool(value)
+        except:
+            raise ValueError("use_releases must be a boolean value")
+
+    @property
+    def user(self):
+        return self._user
+
+    @user.setter
+    def user(self, value):
+        try:
+            self._user = str(value)
+        except:
+            raise ValueError("User must be a string value")
+
+    @property
+    def verbose(self):
+        return self._verbose
+
+    @verbose.setter
+    def verbose(self, value):
+        try:
+            self._verbose = bool(value)
+            self.print_verbose("Verbose is enabled")
+        except:
+            raise ValueError("Verbose must be a boolean value")
+
+    @property
+    def use_print_traces(self):
+        return self._use_print_traces
+
+    @use_print_traces.setter
+    def use_print_traces(self, value):
+        try:
+            self._use_print_traces = bool(value)
+        except:
+            raise ValueError("use_print_traces must be a boolean value")
+
+    @property
+    def version_max_update(self):
+        return self._version_max_update
+
+    @version_max_update.setter
+    def version_max_update(self, value):
+        if value is None:
+            self._version_max_update = None
+            return
+        if not isinstance(value, tuple):
+            raise ValueError("Version maximum must be a tuple")
+        for subvalue in value:
+            if type(subvalue) is not int:
+                raise ValueError("Version elements must be integers")
+        self._version_max_update = value
+
+    @property
+    def version_min_update(self):
+        return self._version_min_update
+
+    @version_min_update.setter
+    def version_min_update(self, value):
+        if value is None:
+            self._version_min_update = None
+            return
+        if not isinstance(value, tuple):
+            raise ValueError("Version minimum must be a tuple")
+        for subvalue in value:
+            if type(subvalue) != int:
+                raise ValueError("Version elements must be integers")
+        self._version_min_update = value
+
+    @property
+    def website(self):
+        return self._website
+
+    @website.setter
+    def website(self, value):
+        if not self.check_is_url(value):
+            raise ValueError("Not a valid URL: " + value)
+        self._website = value
+
+    # -------------------------------------------------------------------------
+    # Parameter validation related functions
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def check_is_url(url):
+        if not ("http://" in url or "https://" in url):
+            return False
+        if "." not in url:
+            return False
+        return True
+
+    def _get_tag_names(self):
+        tag_names = list()
+        self.get_tags()
+        for tag in self._tags:
+            tag_names.append(tag["name"])
+        return tag_names
+
+    def set_check_interval(self, enabled=False,
+                           months=0, days=14, hours=0, minutes=0):
+        """Set the time interval between automated checks, and if enabled.
+
+        Has enabled = False as default to not check against frequency,
+        if enabled, default is 2 weeks.
+        """
+
+        if type(enabled) is not bool:
+            raise ValueError("Enable must be a boolean value")
+        if type(months) is not int:
+            raise ValueError("Months must be an integer value")
+        if type(days) is not int:
+            raise ValueError("Days must be an integer value")
+        if type(hours) is not int:
+            raise ValueError("Hours must be an integer value")
+        if type(minutes) is not int:
+            raise ValueError("Minutes must be an integer value")
+
+        if not enabled:
+            self._check_interval_enabled = False
+        else:
+            self._check_interval_enabled = True
+
+        self._check_interval_months = months
+        self._check_interval_days = days
+        self._check_interval_hours = hours
+        self._check_interval_minutes = minutes
+
+    def __repr__(self):
+        return "<Module updater from {a}>".format(a=__file__)
+
+    def __str__(self):
+        return "Updater, with user: {a}, repository: {b}, url: {c}".format(
+            a=self._user, b=self._repo, c=self.form_repo_url())
+
+    # -------------------------------------------------------------------------
+    # API-related functions
+    # -------------------------------------------------------------------------
+    def form_repo_url(self):
+        return self._engine.form_repo_url(self)
+
+    def form_tags_url(self):
+        return self._engine.form_tags_url(self)
+
+    def form_branch_url(self, branch):
+        return self._engine.form_branch_url(branch, self)
+
+    def get_tags(self):
+        request = self.form_tags_url()
+        self.print_verbose("Getting tags from server")
+
+        # get all tags, internet call
+        all_tags = self._engine.parse_tags(self.get_api(request), self)
+        if all_tags is not None:
+            self._prefiltered_tag_count = len(all_tags)
+        else:
+            self._prefiltered_tag_count = 0
+            all_tags = list()
+
+        # pre-process to skip tags
+        if self.skip_tag is not None:
+            self._tags = [tg for tg in all_tags if not self.skip_tag(self, tg)]
+        else:
+            self._tags = all_tags
+
+        # get additional branches too, if needed, and place in front
+        # Does NO checking here whether branch is valid
+        if self._include_branches:
+            temp_branches = self._include_branch_list.copy()
+            temp_branches.reverse()
+            for branch in temp_branches:
+                request = self.form_branch_url(branch)
+                include = {
+                    "name": branch.title(),
+                    "zipball_url": request
+                }
+                self._tags = [include] + self._tags  # append to front
+
+        if self._tags is None:
+            # some error occurred
+            self._tag_latest = None
+            self._tags = list()
+
+        elif self._prefiltered_tag_count == 0 and not self._include_branches:
+            self._tag_latest = None
+            if self._error is None:  # if not None, could have had no internet
+                self._error = "No releases found"
+                self._error_msg = "No releases or tags found in repository"
+            self.print_verbose("No releases or tags found in repository")
+
+        elif self._prefiltered_tag_count == 0 and self._include_branches:
+            if not self._error:
+                self._tag_latest = self._tags[0]
+            branch = self._include_branch_list[0]
+            self.print_verbose("{} branch found, no releases: {}".format(
+                branch, self._tags[0]))
+
+        elif ((len(self._tags) - len(self._include_branch_list) == 0
+                and self._include_branches)
+                or (len(self._tags) == 0 and not self._include_branches)
+                and self._prefiltered_tag_count > 0):
+            self._tag_latest = None
+            self._error = "No releases available"
+            self._error_msg = "No versions found within compatible version range"
+            self.print_verbose(self._error_msg)
+
+        else:
+            if not self._include_branches:
+                self._tag_latest = self._tags[0]
+                self.print_verbose(
+                    "Most recent tag found:" + str(self._tags[0]['name']))
+            else:
+                # Don't return branch if in list.
+                n = len(self._include_branch_list)
+                self._tag_latest = self._tags[n]  # guaranteed at least len()=n+1
+                self.print_verbose(
+                    "Most recent tag found:" + str(self._tags[n]['name']))
+
+    def get_raw(self, url):
+        """All API calls to base url."""
+        request = urllib.request.Request(url)
+        try:
+            context = ssl._create_unverified_context()
+        except:
+            # Some blender packaged python versions don't have this, largely
+            # useful for local network setups otherwise minimal impact.
+            context = None
+
+        # Setup private request headers if appropriate.
+        if self._engine.token is not None:
+            if self._engine.name == "gitlab":
+                request.add_header('PRIVATE-TOKEN', self._engine.token)
+            else:
+                self.print_verbose("Tokens not setup for engine yet")
+
+        # Always set user agent.
+        request.add_header(
+            'User-Agent', "Python/" + str(platform.python_version()))
+
+        # Run the request.
+        try:
+            if context:
+                result = urllib.request.urlopen(request, context=context)
+            else:
+                result = urllib.request.urlopen(request)
+        except urllib.error.HTTPError as e:
+            if str(e.code) == "403":
+                self._error = "HTTP error (access denied)"
+                self._error_msg = str(e.code) + " - server error response"
+                print(self._error, self._error_msg)
+            else:
+                self._error = "HTTP error"
+                self._error_msg = str(e.code)
+                print(self._error, self._error_msg)
+            self.print_trace()
+            self._update_ready = None
+        except urllib.error.URLError as e:
+            reason = str(e.reason)
+            if "TLSV1_ALERT" in reason or "SSL" in reason.upper():
+                self._error = "Connection rejected, download manually"
+                self._error_msg = reason
+                print(self._error, self._error_msg)
+            else:
+                self._error = "URL error, check internet connection"
+                self._error_msg = reason
+                print(self._error, self._error_msg)
+            self.print_trace()
+            self._update_ready = None
+            return None
+        else:
+            result_string = result.read()
+            result.close()
+            return result_string.decode()
+
+    def get_api(self, url):
+        """Result of all api calls, decoded into json format."""
+        get = None
+        get = self.get_raw(url)
+        if get is not None:
+            try:
+                return json.JSONDecoder().decode(get)
+            except Exception as e:
+                self._error = "API response has invalid JSON format"
+                self._error_msg = str(e.reason)
+                self._update_ready = None
+                print(self._error, self._error_msg)
+                self.print_trace()
+                return None
+        else:
+            return None
+
+    def stage_repository(self, url):
+        """Create a working directory and download the new files"""
+
+        local = os.path.join(self._updater_path, "update_staging")
+        error = None
+
+        # Make/clear the staging folder, to ensure the folder is always clean.
+        self.print_verbose(
+            "Preparing staging folder for download:\n" + str(local))
+        if os.path.isdir(local):
+            try:
+                shutil.rmtree(local)
+                os.makedirs(local)
+            except:
+                error = "failed to remove existing staging directory"
+                self.print_trace()
+        else:
+            try:
+                os.makedirs(local)
+            except:
+                error = "failed to create staging directory"
+                self.print_trace()
+
+        if error is not None:
+            self.print_verbose("Error: Aborting update, " + error)
+            self._error = "Update aborted, staging path error"
+            self._error_msg = "Error: {}".format(error)
+            return False
+
+        if self._backup_current:
+            self.create_backup()
+
+        self.print_verbose("Now retrieving the new source zip")
+        self._source_zip = os.path.join(local, "source.zip")
+        self.print_verbose("Starting download update zip")
+        try:
+            request = urllib.request.Request(url)
+            context = ssl._create_unverified_context()
+
+            # Setup private token if appropriate.
+            if self._engine.token is not None:
+                if self._engine.name == "gitlab":
+                    request.add_header('PRIVATE-TOKEN', self._engine.token)
+                else:
+                    self.print_verbose(
+                        "Tokens not setup for selected engine yet")
+
+            # Always set user agent
+            request.add_header(
+                'User-Agent', "Python/" + str(platform.python_version()))
+
+            self.url_retrieve(urllib.request.urlopen(request, context=context),
+                              self._source_zip)
+            # Add additional checks on file size being non-zero.
+            self.print_verbose("Successfully downloaded update zip")
+            return True
+        except Exception as e:
+            self._error = "Error retrieving download, bad link?"
+            self._error_msg = "Error: {}".format(e)
+            print("Error retrieving download, bad link?")
+            print("Error: {}".format(e))
+            self.print_trace()
+            return False
+
+    def create_backup(self):
+        """Save a backup of the current installed addon prior to an update."""
+        self.print_verbose("Backing up current addon folder")
+        local = os.path.join(self._updater_path, "backup")
+        tempdest = os.path.join(
+            self._addon_root, os.pardir, self._addon + "_updater_backup_temp")
+
+        self.print_verbose("Backup destination path: " + str(local))
+
+        if os.path.isdir(local):
+            try:
+                shutil.rmtree(local)
+            except:
+                self.print_verbose(
+                    "Failed to removed previous backup folder, continuing")
+                self.print_trace()
+
+        # Remove the temp folder.
+        # Shouldn't exist but could if previously interrupted.
+        if os.path.isdir(tempdest):
+            try:
+                shutil.rmtree(tempdest)
+            except:
+                self.print_verbose(
+                    "Failed to remove existing temp folder, continuing")
+                self.print_trace()
+
+        # Make a full addon copy, temporarily placed outside the addon folder.
+        if self._backup_ignore_patterns is not None:
+            try:
+                shutil.copytree(self._addon_root, tempdest,
+                                ignore=shutil.ignore_patterns(
+                                    *self._backup_ignore_patterns))
+            except:
+                print("Failed to create backup, still attempting update.")
+                self.print_trace()
+                return
+        else:
+            try:
+                shutil.copytree(self._addon_root, tempdest)
+            except:
+                print("Failed to create backup, still attempting update.")
+                self.print_trace()
+                return
+        shutil.move(tempdest, local)
+
+        # Save the date for future reference.
+        now = datetime.now()
+        self._json["backup_date"] = "{m}-{d}-{yr}".format(
+            m=now.strftime("%B"), d=now.day, yr=now.year)
+        self.save_updater_json()
+
+    def restore_backup(self):
+        """Restore the last backed up addon version, user initiated only"""
+        self.print_verbose("Restoring backup, backing up current addon folder")
+        backuploc = os.path.join(self._updater_path, "backup")
+        tempdest = os.path.join(
+            self._addon_root, os.pardir, self._addon + "_updater_backup_temp")
+        tempdest = os.path.abspath(tempdest)
+
+        # Move instead contents back in place, instead of copy.
+        shutil.move(backuploc, tempdest)
+        shutil.rmtree(self._addon_root)
+        os.rename(tempdest, self._addon_root)
+
+        self._json["backup_date"] = ""
+        self._json["just_restored"] = True
+        self._json["just_updated"] = True
+        self.save_updater_json()
+
+        self.reload_addon()
+
+    def unpack_staged_zip(self, clean=False):
+        """Unzip the downloaded file, and validate contents"""
+        if not os.path.isfile(self._source_zip):
+            self.print_verbose("Error, update zip not found")
+            self._error = "Install failed"
+            self._error_msg = "Downloaded zip not found"
+            return -1
+
+        # Clear the existing source folder in case previous files remain.
+        outdir = os.path.join(self._updater_path, "source")
+        try:
+            shutil.rmtree(outdir)
+            self.print_verbose("Source folder cleared")
+        except:
+            self.print_trace()
+
+        # Create parent directories if needed, would not be relevant unless
+        # installing addon into another location or via an addon manager.
+        try:
+            os.mkdir(outdir)
+        except Exception as err:
+            print("Error occurred while making extract dir:")
+            print(str(err))
+            self.print_trace()
+            self._error = "Install failed"
+            self._error_msg = "Failed to make extract directory"
+            return -1
+
+        if not os.path.isdir(outdir):
+            print("Failed to create source directory")
+            self._error = "Install failed"
+            self._error_msg = "Failed to create extract directory"
+            return -1
+
+        self.print_verbose(
+            "Begin extracting source from zip:" + str(self._source_zip))
+        with zipfile.ZipFile(self._source_zip, "r") as zfile:
+
+            if not zfile:
+                self._error = "Install failed"
+                self._error_msg = "Resulting file is not a zip, cannot extract"
+                self.print_verbose(self._error_msg)
+                return -1
+
+            # Now extract directly from the first subfolder (not root)
+            # this avoids adding the first subfolder to the path length,
+            # which can be too long if the download has the SHA in the name.
+            zsep = '/'  # Not using os.sep, always the / value even on windows.
+            for name in zfile.namelist():
+                if zsep not in name:
+                    continue
+                top_folder = name[:name.index(zsep) + 1]
+                if name == top_folder + zsep:
+                    continue  # skip top level folder
+                sub_path = name[name.index(zsep) + 1:]
+                if name.endswith(zsep):
+                    try:
+                        os.mkdir(os.path.join(outdir, sub_path))
+                        self.print_verbose(
+                            "Extract - mkdir: " + os.path.join(outdir, sub_path))
+                    except OSError as exc:
+                        if exc.errno != errno.EEXIST:
+                            self._error = "Install failed"
+                            self._error_msg = "Could not create folder from zip"
+                            self.print_trace()
+                            return -1
+                else:
+                    with open(os.path.join(outdir, sub_path), "wb") as outfile:
+                        data = zfile.read(name)
+                        outfile.write(data)
+                        self.print_verbose(
+                            "Extract - create: " + os.path.join(outdir, sub_path))
+
+        self.print_verbose("Extracted source")
+
+        unpath = os.path.join(self._updater_path, "source")
+        if not os.path.isdir(unpath):
+            self._error = "Install failed"
+            self._error_msg = "Extracted path does not exist"
+            print("Extracted path does not exist: ", unpath)
+            return -1
+
+        if self._subfolder_path:
+            self._subfolder_path.replace('/', os.path.sep)
+            self._subfolder_path.replace('\\', os.path.sep)
+
+        # Either directly in root of zip/one subfolder, or use specified path.
+        if not os.path.isfile(os.path.join(unpath, "__init__.py")):
+            dirlist = os.listdir(unpath)
+            if len(dirlist) > 0:
+                if self._subfolder_path == "" or self._subfolder_path is None:
+                    unpath = os.path.join(unpath, dirlist[0])
+                else:
+                    unpath = os.path.join(unpath, self._subfolder_path)
+
+            # Smarter check for additional sub folders for a single folder
+            # containing the __init__.py file.
+            if not os.path.isfile(os.path.join(unpath, "__init__.py")):
+                print("Not a valid addon found")
+                print("Paths:")
+                print(dirlist)
+                self._error = "Install failed"
+                self._error_msg = "No __init__ file found in new source"
+                return -1
+
+        # Merge code with the addon directory, using blender default behavior,
+        # plus any modifiers indicated by user (e.g. force remove/keep).
+        self.deep_merge_directory(self._addon_root, unpath, clean)
+
+        # Now save the json state.
+        # Change to True to trigger the handler on other side if allowing
+        # reloading within same blender session.
+        self._json["just_updated"] = True
+        self.save_updater_json()
+        self.reload_addon()
+        self._update_ready = False
+        return 0
+
+    def deep_merge_directory(self, base, merger, clean=False):
+        """Merge folder 'merger' into 'base' without deleting existing"""
+        if not os.path.exists(base):
+            self.print_verbose("Base path does not exist:" + str(base))
+            return -1
+        elif not os.path.exists(merger):
+            self.print_verbose("Merger path does not exist")
+            return -1
+
+        # Path to be aware of and not overwrite/remove/etc.
+        staging_path = os.path.join(self._updater_path, "update_staging")
+
+        # If clean install is enabled, clear existing files ahead of time
+        # note: will not delete the update.json, update folder, staging, or
+        # staging but will delete all other folders/files in addon directory.
+        error = None
+        if clean:
+            try:
+                # Implement clearing of all folders/files, except the updater
+                # folder and updater json.
+                # Careful, this deletes entire subdirectories recursively...
+                # Make sure that base is not a high level shared folder, but
+                # is dedicated just to the addon itself.
+                self.print_verbose(
+                    "clean=True, clearing addon folder to fresh install state")
+
+                # Remove root files and folders (except update folder).
+                files = [f for f in os.listdir(base)
+                         if os.path.isfile(os.path.join(base, f))]
+                folders = [f for f in os.listdir(base)
+                           if os.path.isdir(os.path.join(base, f))]
+
+                for f in files:
+                    os.remove(os.path.join(base, f))
+                    self.print_verbose(
+                        "Clean removing file {}".format(os.path.join(base, f)))
+                for f in folders:
+                    if os.path.join(base, f) is self._updater_path:
+                        continue
+                    shutil.rmtree(os.path.join(base, f))
+                    self.print_verbose(
+                        "Clean removing folder and contents {}".format(
+                            os.path.join(base, f)))
+
+            except Exception as err:
+                error = "failed to create clean existing addon folder"
+                print(error, str(err))
+                self.print_trace()
+
+        # Walk through the base addon folder for rules on pre-removing
+        # but avoid removing/altering backup and updater file.
+        for path, dirs, files in os.walk(base):
+            # Prune ie skip updater folder.
+            dirs[:] = [d for d in dirs
+                       if os.path.join(path, d) not in [self._updater_path]]
+            for file in files:
+                for pattern in self.remove_pre_update_patterns:
+                    if fnmatch.filter([file], pattern):
+                        try:
+                            fl = os.path.join(path, file)
+                            os.remove(fl)
+                            self.print_verbose("Pre-removed file " + file)
+                        except OSError:
+                            print("Failed to pre-remove " + file)
+                            self.print_trace()
+
+        # Walk through the temp addon sub folder for replacements
+        # this implements the overwrite rules, which apply after
+        # the above pre-removal rules. This also performs the
+        # actual file copying/replacements.
+        for path, dirs, files in os.walk(merger):
+            # Verify structure works to prune updater sub folder overwriting.
+            dirs[:] = [d for d in dirs
+                       if os.path.join(path, d) not in [self._updater_path]]
+            rel_path = os.path.relpath(path, merger)
+            dest_path = os.path.join(base, rel_path)
+            if not os.path.exists(dest_path):
+                os.makedirs(dest_path)
+            for file in files:
+                # Bring in additional logic around copying/replacing.
+                # Blender default: overwrite .py's, don't overwrite the rest.
+                dest_file = os.path.join(dest_path, file)
+                srcFile = os.path.join(path, file)
+
+                # Decide to replace if file already exists, and copy new over.
+                if os.path.isfile(dest_file):
+                    # Otherwise, check each file for overwrite pattern match.
+                    replaced = False
+                    for pattern in self._overwrite_patterns:
+                        if fnmatch.filter([file], pattern):
+                            replaced = True
+                            break
+                    if replaced:
+                        os.remove(dest_file)
+                        os.rename(srcFile, dest_file)
+                        self.print_verbose(
+                            "Overwrote file " + os.path.basename(dest_file))
+                    else:
+                        self.print_verbose(
+                            "Pattern not matched to {}, not overwritten".format(
+                                os.path.basename(dest_file)))
+                else:
+                    # File did not previously exist, simply move it over.
+                    os.rename(srcFile, dest_file)
+                    self.print_verbose(
+                        "New file " + os.path.basename(dest_file))
+
+        # now remove the temp staging folder and downloaded zip
+        try:
+            shutil.rmtree(staging_path)
+        except:
+            error = ("Error: Failed to remove existing staging directory, "
+                     "consider manually removing ") + staging_path
+            self.print_verbose(error)
+            self.print_trace()
+
+    def reload_addon(self):
+        # if post_update false, skip this function
+        # else, unload/reload addon & trigger popup
+        if not self._auto_reload_post_update:
+            print("Restart blender to reload addon and complete update")
+            return
+
+        self.print_verbose("Reloading addon...")
+        addon_utils.modules(refresh=True)
+        bpy.utils.refresh_script_paths()
+
+        # not allowed in restricted context, such as register module
+        # toggle to refresh
+        if "addon_disable" in dir(bpy.ops.wm):  # 2.7
+            bpy.ops.wm.addon_disable(module=self._addon_package)
+            bpy.ops.wm.addon_refresh()
+            bpy.ops.wm.addon_enable(module=self._addon_package)
+            print("2.7 reload complete")
+        else:  # 2.8
+            bpy.ops.preferences.addon_disable(module=self._addon_package)
+            bpy.ops.preferences.addon_refresh()
+            bpy.ops.preferences.addon_enable(module=self._addon_package)
+            print("2.8 reload complete")
+
+    # -------------------------------------------------------------------------
+    # Other non-api functions and setups
+    # -------------------------------------------------------------------------
+    def clear_state(self):
+        self._update_ready = None
+        self._update_link = None
+        self._update_version = None
+        self._source_zip = None
+        self._error = None
+        self._error_msg = None
+
+    def url_retrieve(self, url_file, filepath):
+        """Custom urlretrieve implementation"""
+        chunk = 1024 * 8
+        f = open(filepath, "wb")
+        while 1:
+            data = url_file.read(chunk)
+            if not data:
+                # print("done.")
+                break
+            f.write(data)
+            # print("Read %s bytes" % len(data))
+        f.close()
+
+    def version_tuple_from_text(self, text):
+        """Convert text into a tuple of numbers (int).
+
+        Should go through string and remove all non-integers, and for any
+        given break split into a different section.
+        """
+        if text is None:
+            return ()
+
+        segments = list()
+        tmp = ''
+        for char in str(text):
+            if not char.isdigit():
+                if len(tmp) > 0:
+                    segments.append(int(tmp))
+                    tmp = ''
+            else:
+                tmp += char
+        if len(tmp) > 0:
+            segments.append(int(tmp))
+
+        if len(segments) == 0:
+            self.print_verbose("No version strings found text: " + str(text))
+            if not self._include_branches:
+                return ()
+            else:
+                return (text)
+        return tuple(segments)
+
+    def check_for_update_async(self, callback=None):
+        """Called for running check in a background thread"""
+        is_ready = (
+            self._json is not None
+            and "update_ready" in self._json
+            and self._json["version_text"] != dict()
+            and self._json["update_ready"])
+
+        if is_ready:
+            self._update_ready = True
+            self._update_link = self._json["version_text"]["link"]
+            self._update_version = str(self._json["version_text"]["version"])
+            # Cached update.
+            callback(True)
+            return
+
+        # do the check
+        if not self._check_interval_enabled:
+            return
+        elif self._async_checking:
+            self.print_verbose("Skipping async check, already started")
+            # already running the bg thread
+        elif self._update_ready is None:
+            print("{} updater: Running background check for update".format(
+                  self.addon))
+            self.start_async_check_update(False, callback)
+
+    def check_for_update_now(self, callback=None):
+        self._error = None
+        self._error_msg = None
+        self.print_verbose(
+            "Check update pressed, first getting current status")
+        if self._async_checking:
+            self.print_verbose("Skipping async check, already started")
+            return  # already running the bg thread
+        elif self._update_ready is None:
+            self.start_async_check_update(True, callback)
+        else:
+            self._update_ready = None
+            self.start_async_check_update(True, callback)
+
+    def check_for_update(self, now=False):
+        """Check for update not in a syncrhonous manner.
+
+        This function is not async, will always return in sequential fashion
+        but should have a parent which calls it in another thread.
+        """
+        self.print_verbose("Checking for update function")
+
+        # clear the errors if any
+        self._error = None
+        self._error_msg = None
+
+        # avoid running again in, just return past result if found
+        # but if force now check, then still do it
+        if self._update_ready is not None and not now:
+            return (self._update_ready,
+                    self._update_version,
+                    self._update_link)
+
+        if self._current_version is None:
+            raise ValueError("current_version not yet defined")
+
+        if self._repo is None:
+            raise ValueError("repo not yet defined")
+
+        if self._user is None:
+            raise ValueError("username not yet defined")
+
+        self.set_updater_json()  # self._json
+
+        if not now and not self.past_interval_timestamp():
+            self.print_verbose(
+                "Aborting check for updated, check interval not reached")
+            return (False, None, None)
+
+        # check if using tags or releases
+        # note that if called the first time, this will pull tags from online
+        if self._fake_install:
+            self.print_verbose(
+                "fake_install = True, setting fake version as ready")
+            self._update_ready = True
+            self._update_version = "(999,999,999)"
+            self._update_link = "http://127.0.0.1"
+
+            return (self._update_ready,
+                    self._update_version,
+                    self._update_link)
+
+        # Primary internet call, sets self._tags and self._tag_latest.
+        self.get_tags()
+
+        self._json["last_check"] = str(datetime.now())
+        self.save_updater_json()
+
+        # Can be () or ('master') in addition to branches, and version tag.
+        new_version = self.version_tuple_from_text(self.tag_latest)
+
+        if len(self._tags) == 0:
+            self._update_ready = False
+            self._update_version = None
+            self._update_link = None
+            return (False, None, None)
+
+        if not self._include_branches:
+            link = self.select_link(self, self._tags[0])
+        else:
+            n = len(self._include_branch_list)
+            if len(self._tags) == n:
+                # effectively means no tags found on repo
+                # so provide the first one as default
+                link = self.select_link(self, self._tags[0])
+            else:
+                link = self.select_link(self, self._tags[n])
+
+        if new_version == ():
+            self._update_ready = False
+            self._update_version = None
+            self._update_link = None
+            return (False, None, None)
+        elif str(new_version).lower() in self._include_branch_list:
+            # Handle situation where master/whichever branch is included
+            # however, this code effectively is not triggered now
+            # as new_version will only be tag names, not branch names.
+            if not self._include_branch_auto_check:
+                # Don't offer update as ready, but set the link for the
+                # default branch for installing.
+                self._update_ready = False
+                self._update_version = new_version
+                self._update_link = link
+                self.save_updater_json()
+                return (True, new_version, link)
+            else:
+                # Bypass releases and look at timestamp of last update from a
+                # branch compared to now, see if commit values match or not.
+                raise ValueError("include_branch_autocheck: NOT YET DEVELOPED")
+
+        else:
+            # Situation where branches not included.
+            if new_version > self._current_version:
+
+                self._update_ready = True
+                self._update_version = new_version
+                self._update_link = link
+                self.save_updater_json()
+                return (True, new_version, link)
+
+        # If no update, set ready to False from None to show it was checked.
+        self._update_ready = False
+        self._update_version = None
+        self._update_link = None
+        return (False, None, None)
+
+    def set_tag(self, name):
+        """Assign the tag name and url to update to"""
+        tg = None
+        for tag in self._tags:
+            if name == tag["name"]:
+                tg = tag
+                break
+        if tg:
+            new_version = self.version_tuple_from_text(self.tag_latest)
+            self._update_version = new_version
+            self._update_link = self.select_link(self, tg)
+        elif self._include_branches and name in self._include_branch_list:
+            # scenario if reverting to a specific branch name instead of tag
+            tg = name
+            link = self.form_branch_url(tg)
+            self._update_version = name  # this will break things
+            self._update_link = link
+        if not tg:
+            raise ValueError("Version tag not found: " + name)
+
+    def run_update(self, force=False, revert_tag=None, clean=False, callback=None):
+        """Runs an install, update, or reversion of an addon from online source
+
+        Arguments:
+            force: Install assigned link, even if self.update_ready is False
+            revert_tag: Version to install, if none uses detected update link
+            clean: not used, but in future could use to totally refresh addon
+            callback: used to run function on update completion
+        """
+        self._json["update_ready"] = False
+        self._json["ignore"] = False  # clear ignore flag
+        self._json["version_text"] = dict()
+
+        if revert_tag is not None:
+            self.set_tag(revert_tag)
+            self._update_ready = True
+
+        # clear the errors if any
+        self._error = None
+        self._error_msg = None
+
+        self.print_verbose("Running update")
+
+        if self._fake_install:
+            # Change to True, to trigger the reload/"update installed" handler.
+            self.print_verbose("fake_install=True")
+            self.print_verbose(
+                "Just reloading and running any handler triggers")
+            self._json["just_updated"] = True
+            self.save_updater_json()
+            if self._backup_current is True:
+                self.create_backup()
+            self.reload_addon()
+            self._update_ready = False
+            res = True  # fake "success" zip download flag
+
+        elif not force:
+            if not self._update_ready:
+                self.print_verbose("Update stopped, new version not ready")
+                if callback:
+                    callback(
+                        self._addon_package,
+                        "Update stopped, new version not ready")
+                return "Update stopped, new version not ready"
+            elif self._update_link is None:
+                # this shouldn't happen if update is ready
+                self.print_verbose("Update stopped, update link unavailable")
+                if callback:
+                    callback(self._addon_package,
+                             "Update stopped, update link unavailable")
+                return "Update stopped, update link unavailable"
+
+            if revert_tag is None:
+                self.print_verbose("Staging update")
+            else:
+                self.print_verbose("Staging install")
+
+            res = self.stage_repository(self._update_link)
+            if not res:
+                print("Error in staging repository: " + str(res))
+                if callback is not None:
+                    callback(self._addon_package, self._error_msg)
+                return self._error_msg
+            res = self.unpack_staged_zip(clean)
+            if res < 0:
+                if callback:
+                    callback(self._addon_package, self._error_msg)
+                return res
+
+        else:
+            if self._update_link is None:
+                self.print_verbose("Update stopped, could not get link")
+                return "Update stopped, could not get link"
+            self.print_verbose("Forcing update")
+
+            res = self.stage_repository(self._update_link)
+            if not res:
+                print("Error in staging repository: " + str(res))
+                if callback:
+                    callback(self._addon_package, self._error_msg)
+                return self._error_msg
+            res = self.unpack_staged_zip(clean)
+            if res < 0:
+                return res
+            # would need to compare against other versions held in tags
+
+        # run the front-end's callback if provided
+        if callback:
+            callback(self._addon_package)
+
+        # return something meaningful, 0 means it worked
+        return 0
+
+    def past_interval_timestamp(self):
+        if not self._check_interval_enabled:
+            return True  # ie this exact feature is disabled
+
+        if "last_check" not in self._json or self._json["last_check"] == "":
+            return True
+
+        now = datetime.now()
+        last_check = datetime.strptime(
+            self._json["last_check"], "%Y-%m-%d %H:%M:%S.%f")
+        offset = timedelta(
+            days=self._check_interval_days + 30 * self._check_interval_months,
+            hours=self._check_interval_hours,
+            minutes=self._check_interval_minutes)
+
+        delta = (now - offset) - last_check
+        if delta.total_seconds() > 0:
+            self.print_verbose("Time to check for updates!")
+            return True
+
+        self.print_verbose("Determined it's not yet time to check for updates")
+        return False
+
+    def get_json_path(self):
+        """Returns the full path to the JSON state file used by this updater.
+
+        Will also rename old file paths to addon-specific path if found.
+        """
+        json_path = os.path.join(
+            self._updater_path,
+            "{}_updater_status.json".format(self._addon_package))
+        old_json_path = os.path.join(self._updater_path, "updater_status.json")
+
+        # Rename old file if it exists.
+        try:
+            os.rename(old_json_path, json_path)
+        except FileNotFoundError:
+            pass
+        except Exception as err:
+            print("Other OS error occurred while trying to rename old JSON")
+            print(err)
+            self.print_trace()
+        return json_path
+
+    def set_updater_json(self):
+        """Load or initialize JSON dictionary data for updater state"""
+        if self._updater_path is None:
+            raise ValueError("updater_path is not defined")
+        elif not os.path.isdir(self._updater_path):
+            os.makedirs(self._updater_path)
+
+        jpath = self.get_json_path()
+        if os.path.isfile(jpath):
+            with open(jpath) as data_file:
+                self._json = json.load(data_file)
+                self.print_verbose("Read in JSON settings from file")
+        else:
+            self._json = {
+                "last_check": "",
+                "backup_date": "",
+                "update_ready": False,
+                "ignore": False,
+                "just_restored": False,
+                "just_updated": False,
+                "version_text": dict()
+            }
+            self.save_updater_json()
+
+    def save_updater_json(self):
+        """Trigger save of current json structure into file within addon"""
+        if self._update_ready:
+            if isinstance(self._update_version, tuple):
+                self._json["update_ready"] = True
+                self._json["version_text"]["link"] = self._update_link
+                self._json["version_text"]["version"] = self._update_version
+            else:
+                self._json["update_ready"] = False
+                self._json["version_text"] = dict()
+        else:
+            self._json["update_ready"] = False
+            self._json["version_text"] = dict()
+
+        jpath = self.get_json_path()
+        if not os.path.isdir(os.path.dirname(jpath)):
+            print("State error: Directory does not exist, cannot save json: ",
+                  os.path.basename(jpath))
+            return
+        try:
+            with open(jpath, 'w') as outf:
+                data_out = json.dumps(self._json, indent=4)
+                outf.write(data_out)
+        except:
+            print("Failed to open/save data to json: ", jpath)
+            self.print_trace()
+        self.print_verbose("Wrote out updater JSON settings with content:")
+        self.print_verbose(str(self._json))
+
+    def json_reset_postupdate(self):
+        self._json["just_updated"] = False
+        self._json["update_ready"] = False
+        self._json["version_text"] = dict()
+        self.save_updater_json()
+
+    def json_reset_restore(self):
+        self._json["just_restored"] = False
+        self._json["update_ready"] = False
+        self._json["version_text"] = dict()
+        self.save_updater_json()
+        self._update_ready = None  # Reset so you could check update again.
+
+    def ignore_update(self):
+        self._json["ignore"] = True
+        self.save_updater_json()
+
+    # -------------------------------------------------------------------------
+    # ASYNC related methods
+    # -------------------------------------------------------------------------
+    def start_async_check_update(self, now=False, callback=None):
+        """Start a background thread which will check for updates"""
+        if self._async_checking:
+            return
+        self.print_verbose("Starting background checking thread")
+        check_thread = threading.Thread(target=self.async_check_update,
+                                        args=(now, callback,))
+        check_thread.daemon = True
+        self._check_thread = check_thread
+        check_thread.start()
+
+    def async_check_update(self, now, callback=None):
+        """Perform update check, run as target of background thread"""
+        self._async_checking = True
+        self.print_verbose("Checking for update now in background")
+
+        try:
+            self.check_for_update(now=now)
+        except Exception as exception:
+            print("Checking for update error:")
+            print(exception)
+            self.print_trace()
+            if not self._error:
+                self._update_ready = False
+                self._update_version = None
+                self._update_link = None
+                self._error = "Error occurred"
+                self._error_msg = "Encountered an error while checking for updates"
+
+        self._async_checking = False
+        self._check_thread = None
+
+        if callback:
+            self.print_verbose("Finished check update, doing callback")
+            callback(self._update_ready)
+        self.print_verbose("BG thread: Finished check update, no callback")
+
+    def stop_async_check_update(self):
+        """Method to give impression of stopping check for update.
+
+        Currently does nothing but allows user to retry/stop blocking UI from
+        hitting a refresh button. This does not actually stop the thread, as it
+        will complete after the connection timeout regardless. If the thread
+        does complete with a successful response, this will be still displayed
+        on next UI refresh (ie no update, or update available).
+        """
+        if self._check_thread is not None:
+            self.print_verbose("Thread will end in normal course.")
+            # however, "There is no direct kill method on a thread object."
+            # better to let it run its course
+            # self._check_thread.stop()
+        self._async_checking = False
+        self._error = None
+        self._error_msg = None
+
+
+# -----------------------------------------------------------------------------
+# Updater Engines
+# -----------------------------------------------------------------------------
+
+
+class BitbucketEngine:
+    """Integration to Bitbucket API for git-formatted repositories"""
+
+    def __init__(self):
+        self.api_url = 'https://api.bitbucket.org'
+        self.token = None
+        self.name = "bitbucket"
+
+    def form_repo_url(self, updater):
+        return "{}/2.0/repositories/{}/{}".format(
+            self.api_url, updater.user, updater.repo)
+
+    def form_tags_url(self, updater):
+        return self.form_repo_url(updater) + "/refs/tags?sort=-name"
+
+    def form_branch_url(self, branch, updater):
+        return self.get_zip_url(branch, updater)
+
+    def get_zip_url(self, name, updater):
+        return "https://bitbucket.org/{user}/{repo}/get/{name}.zip".format(
+            user=updater.user,
+            repo=updater.repo,
+            name=name)
+
+    def parse_tags(self, response, updater):
+        if response is None:
+            return list()
+        return [
+            {
+                "name": tag["name"],
+                "zipball_url": self.get_zip_url(tag["name"], updater)
+            } for tag in response["values"]]
+
+
+class GithubEngine:
+    """Integration to Github API"""
+
+    def __init__(self):
+        self.api_url = 'https://api.github.com'
+        self.token = None
+        self.name = "github"
+
+    def form_repo_url(self, updater):
+        return "{}/repos/{}/{}".format(
+            self.api_url, updater.user, updater.repo)
+
+    def form_tags_url(self, updater):
+        if updater.use_releases:
+            return "{}/releases".format(self.form_repo_url(updater))
+        else:
+            return "{}/tags".format(self.form_repo_url(updater))
+
+    def form_branch_list_url(self, updater):
+        return "{}/branches".format(self.form_repo_url(updater))
+
+    def form_branch_url(self, branch, updater):
+        return "{}/zipball/{}".format(self.form_repo_url(updater), branch)
+
+    def parse_tags(self, response, updater):
+        if response is None:
+            return list()
+        return response
+
+
+class GitlabEngine:
+    """Integration to GitLab API"""
+
+    def __init__(self):
+        self.api_url = 'https://gitlab.com'
+        self.token = None
+        self.name = "gitlab"
+
+    def form_repo_url(self, updater):
+        return "{}/api/v4/projects/{}".format(self.api_url, updater.repo)
+
+    def form_tags_url(self, updater):
+        return "{}/repository/tags".format(self.form_repo_url(updater))
+
+    def form_branch_list_url(self, updater):
+        # does not validate branch name.
+        return "{}/repository/branches".format(
+            self.form_repo_url(updater))
+
+    def form_branch_url(self, branch, updater):
+        # Could clash with tag names and if it does, it will download TAG zip
+        # instead of branch zip to get direct path, would need.
+        return "{}/repository/archive.zip?sha={}".format(
+            self.form_repo_url(updater), branch)
+
+    def get_zip_url(self, sha, updater):
+        return "{base}/repository/archive.zip?sha={sha}".format(
+            base=self.form_repo_url(updater),
+            sha=sha)
+
+    # def get_commit_zip(self, id, updater):
+    # 	return self.form_repo_url(updater)+"/repository/archive.zip?sha:"+id
+
+    def parse_tags(self, response, updater):
+        if response is None:
+            return list()
+        return [
+            {
+                "name": tag["name"],
+                "zipball_url": self.get_zip_url(tag["commit"]["id"], updater)
+            } for tag in response]
+
+
+# -----------------------------------------------------------------------------
+# The module-shared class instance,
+# should be what's imported to other files
+# -----------------------------------------------------------------------------
+
+Updater = SingletonUpdater()

--- a/addon/addon_updater_ops.py
+++ b/addon/addon_updater_ops.py
@@ -1,0 +1,1538 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+"""Blender UI integrations for the addon updater.
+
+Implements draw calls, popups, and operators that use the addon_updater.
+"""
+
+import os
+import traceback
+
+import bpy
+from bpy.app.handlers import persistent
+
+# Safely import the updater.
+# Prevents popups for users with invalid python installs e.g. missing libraries
+# and will replace with a fake class instead if it fails (so UI draws work).
+try:
+    from .addon_updater import Updater as updater
+except Exception as e:
+    print("ERROR INITIALIZING UPDATER")
+    print(str(e))
+    traceback.print_exc()
+
+    class SingletonUpdaterNone(object):
+        """Fake, bare minimum fields and functions for the updater object."""
+
+        def __init__(self):
+            self.invalid_updater = True  # Used to distinguish bad install.
+
+            self.addon = None
+            self.verbose = False
+            self.use_print_traces = True
+            self.error = None
+            self.error_msg = None
+            self.async_checking = None
+
+        def clear_state(self):
+            self.addon = None
+            self.verbose = False
+            self.invalid_updater = True
+            self.error = None
+            self.error_msg = None
+            self.async_checking = None
+
+        def run_update(self, force, callback, clean):
+            pass
+
+        def check_for_update(self, now):
+            pass
+
+    updater = SingletonUpdaterNone()
+    updater.error = "Error initializing updater module"
+    updater.error_msg = str(e)
+
+# Must declare this before classes are loaded, otherwise the bl_idname's will
+# not match and have errors. Must be all lowercase and no spaces! Should also
+# be unique among any other addons that could exist (using this updater code),
+# to avoid clashes in operator registration.
+updater.addon = "open_jaywalker"
+
+
+# -----------------------------------------------------------------------------
+# Blender version utils
+# -----------------------------------------------------------------------------
+def make_annotations(cls):
+    """Add annotation attribute to fields to avoid Blender 2.8+ warnings"""
+    if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
+        return cls
+    if bpy.app.version < (2, 93, 0):
+        bl_props = {k: v for k, v in cls.__dict__.items()
+                    if isinstance(v, tuple)}
+    else:
+        bl_props = {k: v for k, v in cls.__dict__.items()
+                    if isinstance(v, bpy.props._PropertyDeferred)}
+    if bl_props:
+        if '__annotations__' not in cls.__dict__:
+            setattr(cls, '__annotations__', {})
+        annotations = cls.__dict__['__annotations__']
+        for k, v in bl_props.items():
+            annotations[k] = v
+            delattr(cls, k)
+    return cls
+
+
+def layout_split(layout, factor=0.0, align=False):
+    """Intermediate method for pre and post blender 2.8 split UI function"""
+    if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
+        return layout.split(percentage=factor, align=align)
+    return layout.split(factor=factor, align=align)
+
+
+def get_user_preferences(context=None):
+    """Intermediate method for pre and post blender 2.8 grabbing preferences"""
+    if not context:
+        context = bpy.context
+    prefs = None
+    if hasattr(context, "user_preferences"):
+        prefs = context.user_preferences.addons.get(__package__, None)
+    elif hasattr(context, "preferences"):
+        prefs = context.preferences.addons.get(__package__, None)
+    if prefs:
+        return prefs.preferences
+    # To make the addon stable and non-exception prone, return None
+    # raise Exception("Could not fetch user preferences")
+    return None
+
+
+# -----------------------------------------------------------------------------
+# Updater operators
+# -----------------------------------------------------------------------------
+
+
+# Simple popup to prompt use to check for update & offer install if available.
+class AddonUpdaterInstallPopup(bpy.types.Operator):
+    """Check and install update if available"""
+    bl_label = "Update {x} addon".format(x=updater.addon)
+    bl_idname = updater.addon + ".updater_install_popup"
+    bl_description = "Popup to check and display current updates available"
+    bl_options = {'REGISTER', 'INTERNAL'}
+
+    # if true, run clean install - ie remove all files before adding new
+    # equivalent to deleting the addon and reinstalling, except the
+    # updater folder/backup folder remains
+    clean_install = bpy.props.BoolProperty(
+        name="Clean install",
+        description=("If enabled, completely clear the addon's folder before "
+                     "installing new update, creating a fresh install"),
+        default=False,
+        options={'HIDDEN'}
+    )
+
+    ignore_enum = bpy.props.EnumProperty(
+        name="Process update",
+        description="Decide to install, ignore, or defer new addon update",
+        items=[
+            ("install", "Update Now", "Install update now"),
+            ("ignore", "Ignore", "Ignore this update to prevent future popups"),
+            ("defer", "Defer", "Defer choice till next blender session")
+        ],
+        options={'HIDDEN'}
+    )
+
+    def check(self, context):
+        return True
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context):
+        layout = self.layout
+        if updater.invalid_updater:
+            layout.label(text="Updater module error")
+            return
+        elif updater.update_ready:
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="Update {} ready!".format(updater.update_version),
+                      icon="LOOP_FORWARDS")
+            col.label(text="Choose 'Update Now' & press OK to install, ",
+                      icon="BLANK1")
+            col.label(text="or click outside window to defer", icon="BLANK1")
+            row = col.row()
+            row.prop(self, "ignore_enum", expand=True)
+            col.split()
+        elif not updater.update_ready:
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="No updates available")
+            col.label(text="Press okay to dismiss dialog")
+            # add option to force install
+        else:
+            # Case: updater.update_ready = None
+            # we have not yet checked for the update.
+            layout.label(text="Check for update now?")
+
+        # Potentially in future, UI to 'check to select/revert to old version'.
+
+    def execute(self, context):
+        # In case of error importing updater.
+        if updater.invalid_updater:
+            return {'CANCELLED'}
+
+        if updater.manual_only:
+            bpy.ops.wm.url_open(url=updater.website)
+        elif updater.update_ready:
+
+            # Action based on enum selection.
+            if self.ignore_enum == 'defer':
+                return {'FINISHED'}
+            elif self.ignore_enum == 'ignore':
+                updater.ignore_update()
+                return {'FINISHED'}
+
+            res = updater.run_update(force=False,
+                                     callback=post_update_callback,
+                                     clean=self.clean_install)
+
+            # Should return 0, if not something happened.
+            if updater.verbose:
+                if res == 0:
+                    print("Updater returned successful")
+                else:
+                    print("Updater returned {}, error occurred".format(res))
+        elif updater.update_ready is None:
+            _ = updater.check_for_update(now=True)
+
+            # Re-launch this dialog.
+            atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+            getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+        else:
+            updater.print_verbose("Doing nothing, not ready for update")
+        return {'FINISHED'}
+
+
+# User preference check-now operator
+class AddonUpdaterCheckNow(bpy.types.Operator):
+    bl_label = "Check now for " + updater.addon + " update"
+    bl_idname = updater.addon + ".updater_check_now"
+    bl_description = "Check now for an update to the {} addon".format(
+        updater.addon)
+    bl_options = {'REGISTER', 'INTERNAL'}
+
+    def execute(self, context):
+        if updater.invalid_updater:
+            return {'CANCELLED'}
+
+        if updater.async_checking and updater.error is None:
+            # Check already happened.
+            # Used here to just avoid constant applying settings below.
+            # Ignoring if error, to prevent being stuck on the error screen.
+            return {'CANCELLED'}
+
+        # apply the UI settings
+        settings = get_user_preferences(context)
+        if not settings:
+            updater.print_verbose(
+                "Could not get {} preferences, update check skipped".format(
+                    __package__))
+            return {'CANCELLED'}
+
+        updater.set_check_interval(
+            enabled=settings.auto_check_update,
+            months=settings.updater_interval_months,
+            days=settings.updater_interval_days,
+            hours=settings.updater_interval_hours,
+            minutes=settings.updater_interval_minutes)
+
+        # Input is an optional callback function. This function should take a
+        # bool input. If true: update ready, if false: no update ready.
+        updater.check_for_update_now(ui_refresh)
+
+        return {'FINISHED'}
+
+
+class AddonUpdaterUpdateNow(bpy.types.Operator):
+    bl_label = "Update " + updater.addon + " addon now"
+    bl_idname = updater.addon + ".updater_update_now"
+    bl_description = "Update to the latest version of the {x} addon".format(
+        x=updater.addon)
+    bl_options = {'REGISTER', 'INTERNAL'}
+
+    # If true, run clean install - ie remove all files before adding new
+    # equivalent to deleting the addon and reinstalling, except the updater
+    # folder/backup folder remains.
+    clean_install = bpy.props.BoolProperty(
+        name="Clean install",
+        description=("If enabled, completely clear the addon's folder before "
+                     "installing new update, creating a fresh install"),
+        default=False,
+        options={'HIDDEN'}
+    )
+
+    def execute(self, context):
+
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {'CANCELLED'}
+
+        if updater.manual_only:
+            bpy.ops.wm.url_open(url=updater.website)
+        if updater.update_ready:
+            # if it fails, offer to open the website instead
+            try:
+                res = updater.run_update(force=False,
+                                         callback=post_update_callback,
+                                         clean=self.clean_install)
+
+                # Should return 0, if not something happened.
+                if updater.verbose:
+                    if res == 0:
+                        print("Updater returned successful")
+                    else:
+                        print("Updater error response: {}".format(res))
+            except Exception as expt:
+                updater._error = "Error trying to run update"
+                updater._error_msg = str(expt)
+                updater.print_trace()
+                atr = AddonUpdaterInstallManually.bl_idname.split(".")
+                getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+        elif updater.update_ready is None:
+            (update_ready, version, link) = updater.check_for_update(now=True)
+            # Re-launch this dialog.
+            atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+            getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+
+        elif not updater.update_ready:
+            self.report({'INFO'}, "Nothing to update")
+            return {'CANCELLED'}
+        else:
+            self.report(
+                {'ERROR'}, "Encountered a problem while trying to update")
+            return {'CANCELLED'}
+
+        return {'FINISHED'}
+
+
+class AddonUpdaterUpdateTarget(bpy.types.Operator):
+    bl_label = updater.addon + " version target"
+    bl_idname = updater.addon + ".updater_update_target"
+    bl_description = "Install a targeted version of the {x} addon".format(
+        x=updater.addon)
+    bl_options = {'REGISTER', 'INTERNAL'}
+
+    def target_version(self, context):
+        # In case of error importing updater.
+        if updater.invalid_updater:
+            ret = []
+
+        ret = []
+        i = 0
+        for tag in updater.tags:
+            ret.append((tag, tag, "Select to install " + tag))
+            i += 1
+        return ret
+
+    target = bpy.props.EnumProperty(
+        name="Target version to install",
+        description="Select the version to install",
+        items=target_version
+    )
+
+    # If true, run clean install - ie remove all files before adding new
+    # equivalent to deleting the addon and reinstalling, except the
+    # updater folder/backup folder remains.
+    clean_install = bpy.props.BoolProperty(
+        name="Clean install",
+        description=("If enabled, completely clear the addon's folder before "
+                     "installing new update, creating a fresh install"),
+        default=False,
+        options={'HIDDEN'}
+    )
+
+    @classmethod
+    def poll(cls, context):
+        if updater.invalid_updater:
+            return False
+        return updater.update_ready is not None and len(updater.tags) > 0
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context):
+        layout = self.layout
+        if updater.invalid_updater:
+            layout.label(text="Updater error")
+            return
+        split = layout_split(layout, factor=0.5)
+        sub_col = split.column()
+        sub_col.label(text="Select install version")
+        sub_col = split.column()
+        sub_col.prop(self, "target", text="")
+
+    def execute(self, context):
+        # In case of error importing updater.
+        if updater.invalid_updater:
+            return {'CANCELLED'}
+
+        res = updater.run_update(
+            force=False,
+            revert_tag=self.target,
+            callback=post_update_callback,
+            clean=self.clean_install)
+
+        # Should return 0, if not something happened.
+        if res == 0:
+            updater.print_verbose("Updater returned successful")
+        else:
+            updater.print_verbose(
+                "Updater returned {}, , error occurred".format(res))
+            return {'CANCELLED'}
+
+        return {'FINISHED'}
+
+
+class AddonUpdaterInstallManually(bpy.types.Operator):
+    """As a fallback, direct the user to download the addon manually"""
+    bl_label = "Install update manually"
+    bl_idname = updater.addon + ".updater_install_manually"
+    bl_description = "Proceed to manually install update"
+    bl_options = {'REGISTER', 'INTERNAL'}
+
+    error = bpy.props.StringProperty(
+        name="Error Occurred",
+        default="",
+        options={'HIDDEN'}
+    )
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_popup(self)
+
+    def draw(self, context):
+        layout = self.layout
+
+        if updater.invalid_updater:
+            layout.label(text="Updater error")
+            return
+
+        # Display error if a prior autoamted install failed.
+        if self.error != "":
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="There was an issue trying to auto-install",
+                      icon="ERROR")
+            col.label(text="Press the download button below and install",
+                      icon="BLANK1")
+            col.label(text="the zip file like a normal addon.", icon="BLANK1")
+        else:
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="Install the addon manually")
+            col.label(text="Press the download button below and install")
+            col.label(text="the zip file like a normal addon.")
+
+        # If check hasn't happened, i.e. accidentally called this menu,
+        # allow to check here.
+
+        row = layout.row()
+
+        if updater.update_link is not None:
+            row.operator(
+                "wm.url_open",
+                text="Direct download").url = updater.update_link
+        else:
+            row.operator(
+                "wm.url_open",
+                text="(failed to retrieve direct download)")
+            row.enabled = False
+
+            if updater.website is not None:
+                row = layout.row()
+                ops = row.operator("wm.url_open", text="Open website")
+                ops.url = updater.website
+            else:
+                row = layout.row()
+                row.label(text="See source website to download the update")
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+
+class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
+    """Addon in place, popup telling user it completed or what went wrong"""
+    bl_label = "Installation Report"
+    bl_idname = updater.addon + ".updater_update_successful"
+    bl_description = "Update installation response"
+    bl_options = {'REGISTER', 'INTERNAL', 'UNDO'}
+
+    error = bpy.props.StringProperty(
+        name="Error Occurred",
+        default="",
+        options={'HIDDEN'}
+    )
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_popup(self, event)
+
+    def draw(self, context):
+        layout = self.layout
+
+        if updater.invalid_updater:
+            layout.label(text="Updater error")
+            return
+
+        saved = updater.json
+        if self.error != "":
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="Error occurred, did not install", icon="ERROR")
+            if updater.error_msg:
+                msg = updater.error_msg
+            else:
+                msg = self.error
+            col.label(text=str(msg), icon="BLANK1")
+            rw = col.row()
+            rw.scale_y = 2
+            rw.operator(
+                "wm.url_open",
+                text="Click for manual download.",
+                icon="BLANK1").url = updater.website
+        elif not updater.auto_reload_post_update:
+            # Tell user to restart blender after an update/restore!
+            if "just_restored" in saved and saved["just_restored"]:
+                col = layout.column()
+                col.label(text="Addon restored", icon="RECOVER_LAST")
+                alert_row = col.row()
+                alert_row.alert = True
+                alert_row.operator(
+                    "wm.quit_blender",
+                    text="Restart blender to reload",
+                    icon="BLANK1")
+                updater.json_reset_restore()
+            else:
+                col = layout.column()
+                col.label(
+                    text="Addon successfully installed", icon="FILE_TICK")
+                alert_row = col.row()
+                alert_row.alert = True
+                alert_row.operator(
+                    "wm.quit_blender",
+                    text="Restart blender to reload",
+                    icon="BLANK1")
+
+        else:
+            # reload addon, but still recommend they restart blender
+            if "just_restored" in saved and saved["just_restored"]:
+                col = layout.column()
+                col.scale_y = 0.7
+                col.label(text="Addon restored", icon="RECOVER_LAST")
+                col.label(
+                    text="Consider restarting blender to fully reload.",
+                    icon="BLANK1")
+                updater.json_reset_restore()
+            else:
+                col = layout.column()
+                col.scale_y = 0.7
+                col.label(
+                    text="Addon successfully installed", icon="FILE_TICK")
+                col.label(
+                    text="Consider restarting blender to fully reload.",
+                    icon="BLANK1")
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+
+class AddonUpdaterRestoreBackup(bpy.types.Operator):
+    """Restore addon from backup"""
+    bl_label = "Restore backup"
+    bl_idname = updater.addon + ".updater_restore_backup"
+    bl_description = "Restore addon from backup"
+    bl_options = {'REGISTER', 'INTERNAL'}
+
+    @classmethod
+    def poll(cls, context):
+        try:
+            return os.path.isdir(os.path.join(updater.stage_path, "backup"))
+        except:
+            return False
+
+    def execute(self, context):
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {'CANCELLED'}
+        updater.restore_backup()
+        return {'FINISHED'}
+
+
+class AddonUpdaterIgnore(bpy.types.Operator):
+    """Ignore update to prevent future popups"""
+    bl_label = "Ignore update"
+    bl_idname = updater.addon + ".updater_ignore"
+    bl_description = "Ignore update to prevent future popups"
+    bl_options = {'REGISTER', 'INTERNAL'}
+
+    @classmethod
+    def poll(cls, context):
+        if updater.invalid_updater:
+            return False
+        elif updater.update_ready:
+            return True
+        else:
+            return False
+
+    def execute(self, context):
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {'CANCELLED'}
+        updater.ignore_update()
+        self.report({"INFO"}, "Open addon preferences for updater options")
+        return {'FINISHED'}
+
+
+class AddonUpdaterEndBackground(bpy.types.Operator):
+    """Stop checking for update in the background"""
+    bl_label = "End background check"
+    bl_idname = updater.addon + ".end_background_check"
+    bl_description = "Stop checking for update in the background"
+    bl_options = {'REGISTER', 'INTERNAL'}
+
+    def execute(self, context):
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {'CANCELLED'}
+        updater.stop_async_check_update()
+        return {'FINISHED'}
+
+
+# -----------------------------------------------------------------------------
+# Handler related, to create popups
+# -----------------------------------------------------------------------------
+
+
+# global vars used to prevent duplicate popup handlers
+ran_auto_check_install_popup = False
+ran_update_success_popup = False
+
+# global var for preventing successive calls
+ran_background_check = False
+
+
+@persistent
+def updater_run_success_popup_handler(scene):
+    global ran_update_success_popup
+    ran_update_success_popup = True
+
+    # in case of error importing updater
+    if updater.invalid_updater:
+        return
+
+    try:
+        if "scene_update_post" in dir(bpy.app.handlers):
+            bpy.app.handlers.scene_update_post.remove(
+                updater_run_success_popup_handler)
+        else:
+            bpy.app.handlers.depsgraph_update_post.remove(
+                updater_run_success_popup_handler)
+    except:
+        pass
+
+    atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
+    getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+
+
+@persistent
+def updater_run_install_popup_handler(scene):
+    global ran_auto_check_install_popup
+    ran_auto_check_install_popup = True
+    updater.print_verbose("Running the install popup handler.")
+
+    # in case of error importing updater
+    if updater.invalid_updater:
+        return
+
+    try:
+        if "scene_update_post" in dir(bpy.app.handlers):
+            bpy.app.handlers.scene_update_post.remove(
+                updater_run_install_popup_handler)
+        else:
+            bpy.app.handlers.depsgraph_update_post.remove(
+                updater_run_install_popup_handler)
+    except:
+        pass
+
+    if "ignore" in updater.json and updater.json["ignore"]:
+        return  # Don't do popup if ignore pressed.
+    elif "version_text" in updater.json and updater.json["version_text"].get("version"):
+        version = updater.json["version_text"]["version"]
+        ver_tuple = updater.version_tuple_from_text(version)
+
+        if ver_tuple < updater.current_version:
+            # User probably manually installed to get the up to date addon
+            # in here. Clear out the update flag using this function.
+            updater.print_verbose(
+                "{} updater: appears user updated, clearing flag".format(
+                    updater.addon))
+            updater.json_reset_restore()
+            return
+    atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+    getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+
+
+def background_update_callback(update_ready):
+    """Passed into the updater, background thread updater"""
+    global ran_auto_check_install_popup
+    updater.print_verbose("Running background update callback")
+
+    # In case of error importing updater.
+    if updater.invalid_updater:
+        return
+    if not updater.show_popups:
+        return
+    if not update_ready:
+        return
+
+    # See if we need add to the update handler to trigger the popup.
+    handlers = []
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        handlers = bpy.app.handlers.scene_update_post
+    else:  # 2.8+
+        handlers = bpy.app.handlers.depsgraph_update_post
+    in_handles = updater_run_install_popup_handler in handlers
+
+    if in_handles or ran_auto_check_install_popup:
+        return
+
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        bpy.app.handlers.scene_update_post.append(
+            updater_run_install_popup_handler)
+    else:  # 2.8+
+        bpy.app.handlers.depsgraph_update_post.append(
+            updater_run_install_popup_handler)
+    ran_auto_check_install_popup = True
+    updater.print_verbose("Attempted popup prompt")
+
+
+def post_update_callback(module_name, res=None):
+    """Callback for once the run_update function has completed.
+
+    Only makes sense to use this if "auto_reload_post_update" == False,
+    i.e. don't auto-restart the addon.
+
+    Arguments:
+        module_name: returns the module name from updater, but unused here.
+        res: If an error occurred, this is the detail string.
+    """
+
+    # In case of error importing updater.
+    if updater.invalid_updater:
+        return
+
+    if res is None:
+        # This is the same code as in conditional at the end of the register
+        # function, ie if "auto_reload_post_update" == True, skip code.
+        updater.print_verbose(
+            "{} updater: Running post update callback".format(updater.addon))
+
+        atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
+        getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+        global ran_update_success_popup
+        ran_update_success_popup = True
+    else:
+        # Some kind of error occurred and it was unable to install, offer
+        # manual download instead.
+        atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
+        getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT', error=res)
+    return
+
+
+def ui_refresh(update_status):
+    """Redraw the ui once an async thread has completed"""
+    for windowManager in bpy.data.window_managers:
+        for window in windowManager.windows:
+            for area in window.screen.areas:
+                area.tag_redraw()
+
+
+def check_for_update_background():
+    """Function for asynchronous background check.
+
+    *Could* be called on register, but would be bad practice as the bare
+    minimum code should run at the moment of registration (addon ticked).
+    """
+    if updater.invalid_updater:
+        return
+    global ran_background_check
+    if ran_background_check:
+        # Global var ensures check only happens once.
+        return
+    elif updater.update_ready is not None or updater.async_checking:
+        # Check already happened.
+        # Used here to just avoid constant applying settings below.
+        return
+
+    # Apply the UI settings.
+    settings = get_user_preferences(bpy.context)
+    if not settings:
+        return
+    updater.set_check_interval(enabled=settings.auto_check_update,
+                               months=settings.updater_interval_months,
+                               days=settings.updater_interval_days,
+                               hours=settings.updater_interval_hours,
+                               minutes=settings.updater_interval_minutes)
+
+    # Input is an optional callback function. This function should take a bool
+    # input, if true: update ready, if false: no update ready.
+    updater.check_for_update_async(background_update_callback)
+    ran_background_check = True
+
+
+def check_for_update_nonthreaded(self, context):
+    """Can be placed in front of other operators to launch when pressed"""
+    if updater.invalid_updater:
+        return
+
+    # Only check if it's ready, ie after the time interval specified should
+    # be the async wrapper call here.
+    settings = get_user_preferences(bpy.context)
+    if not settings:
+        if updater.verbose:
+            print("Could not get {} preferences, update check skipped".format(
+                __package__))
+        return
+    updater.set_check_interval(enabled=settings.auto_check_update,
+                               months=settings.updater_interval_months,
+                               days=settings.updater_interval_days,
+                               hours=settings.updater_interval_hours,
+                               minutes=settings.updater_interval_minutes)
+
+    (update_ready, version, link) = updater.check_for_update(now=False)
+    if update_ready:
+        atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+        getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+    else:
+        updater.print_verbose("No update ready")
+        self.report({'INFO'}, "No update ready")
+
+
+def show_reload_popup():
+    """For use in register only, to show popup after re-enabling the addon.
+
+    Must be enabled by developer.
+    """
+    if updater.invalid_updater:
+        return
+    saved_state = updater.json
+    global ran_update_success_popup
+
+    has_state = saved_state is not None
+    just_updated = "just_updated" in saved_state
+    updated_info = saved_state["just_updated"]
+
+    if not (has_state and just_updated and updated_info):
+        return
+
+    updater.json_reset_postupdate()  # So this only runs once.
+
+    # No handlers in this case.
+    if not updater.auto_reload_post_update:
+        return
+
+    # See if we need add to the update handler to trigger the popup.
+    handlers = []
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        handlers = bpy.app.handlers.scene_update_post
+    else:  # 2.8+
+        handlers = bpy.app.handlers.depsgraph_update_post
+    in_handles = updater_run_success_popup_handler in handlers
+
+    if in_handles or ran_update_success_popup:
+        return
+
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        bpy.app.handlers.scene_update_post.append(
+            updater_run_success_popup_handler)
+    else:  # 2.8+
+        bpy.app.handlers.depsgraph_update_post.append(
+            updater_run_success_popup_handler)
+    ran_update_success_popup = True
+
+
+# -----------------------------------------------------------------------------
+# Example UI integrations
+# -----------------------------------------------------------------------------
+def update_notice_box_ui(self, context):
+    """Update notice draw, to add to the end or beginning of a panel.
+
+    After a check for update has occurred, this function will draw a box
+    saying an update is ready, and give a button for: update now, open website,
+    or ignore popup. Ideal to be placed at the end / beginning of a panel.
+    """
+
+    if updater.invalid_updater:
+        return
+
+    saved_state = updater.json
+    if not updater.auto_reload_post_update:
+        if "just_updated" in saved_state and saved_state["just_updated"]:
+            layout = self.layout
+            box = layout.box()
+            col = box.column()
+            alert_row = col.row()
+            alert_row.alert = True
+            alert_row.operator(
+                "wm.quit_blender",
+                text="Restart blender",
+                icon="ERROR")
+            col.label(text="to complete update")
+            return
+
+    # If user pressed ignore, don't draw the box.
+    if "ignore" in updater.json and updater.json["ignore"]:
+        return
+    if not updater.update_ready:
+        return
+
+    layout = self.layout
+    box = layout.box()
+    col = box.column(align=True)
+    col.alert = True
+    col.label(text="Update ready!", icon="ERROR")
+    col.alert = False
+    col.separator()
+    row = col.row(align=True)
+    split = row.split(align=True)
+    colL = split.column(align=True)
+    colL.scale_y = 1.5
+    colL.operator(AddonUpdaterIgnore.bl_idname, icon="X", text="Ignore")
+    colR = split.column(align=True)
+    colR.scale_y = 1.5
+    if not updater.manual_only:
+        colR.operator(AddonUpdaterUpdateNow.bl_idname,
+                      text="Update", icon="LOOP_FORWARDS")
+        col.operator("wm.url_open", text="Open website").url = updater.website
+        # ops = col.operator("wm.url_open",text="Direct download")
+        # ops.url=updater.update_link
+        col.operator(AddonUpdaterInstallManually.bl_idname,
+                     text="Install manually")
+    else:
+        # ops = col.operator("wm.url_open", text="Direct download")
+        # ops.url=updater.update_link
+        col.operator("wm.url_open", text="Get it now").url = updater.website
+
+
+def update_settings_ui(self, context, element=None):
+    """Preferences - for drawing with full width inside user preferences
+
+    A function that can be run inside user preferences panel for prefs UI.
+    Place inside UI draw using:
+        addon_updater_ops.update_settings_ui(self, context)
+    or by:
+        addon_updater_ops.update_settings_ui(context)
+    """
+
+    # Element is a UI element, such as layout, a row, column, or box.
+    if element is None:
+        element = self.layout
+    box = element.box()
+
+    # In case of error importing updater.
+    if updater.invalid_updater:
+        box.label(text="Error initializing updater code:")
+        box.label(text=updater.error_msg)
+        return
+    settings = get_user_preferences(context)
+    if not settings:
+        box.label(text="Error getting updater preferences", icon='ERROR')
+        return
+
+    # auto-update settings
+    box.label(text="Updater Settings")
+    row = box.row()
+
+    # special case to tell user to restart blender, if set that way
+    if not updater.auto_reload_post_update:
+        saved_state = updater.json
+        if "just_updated" in saved_state and saved_state["just_updated"]:
+            row.alert = True
+            row.operator("wm.quit_blender",
+                         text="Restart blender to complete update",
+                         icon="ERROR")
+            return
+
+    split = layout_split(row, factor=0.4)
+    sub_col = split.column()
+    sub_col.prop(settings, "auto_check_update")
+    sub_col = split.column()
+
+    if not settings.auto_check_update:
+        sub_col.enabled = False
+    sub_row = sub_col.row()
+    sub_row.label(text="Interval between checks")
+    sub_row = sub_col.row(align=True)
+    check_col = sub_row.column(align=True)
+    check_col.prop(settings, "updater_interval_months")
+    check_col = sub_row.column(align=True)
+    check_col.prop(settings, "updater_interval_days")
+    check_col = sub_row.column(align=True)
+
+    # Consider un-commenting for local dev (e.g. to set shorter intervals)
+    # check_col.prop(settings,"updater_interval_hours")
+    # check_col = sub_row.column(align=True)
+    # check_col.prop(settings,"updater_interval_minutes")
+
+    # Checking / managing updates.
+    row = box.row()
+    col = row.column()
+    if updater.error is not None:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        if "ssl" in updater.error_msg.lower():
+            split.enabled = True
+            split.operator(AddonUpdaterInstallManually.bl_idname,
+                           text=updater.error)
+        else:
+            split.enabled = False
+            split.operator(AddonUpdaterCheckNow.bl_idname,
+                           text=updater.error)
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
+
+    elif updater.update_ready is None and not updater.async_checking:
+        col.scale_y = 2
+        col.operator(AddonUpdaterCheckNow.bl_idname)
+    elif updater.update_ready is None:  # async is running
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="Checking...")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterEndBackground.bl_idname, text="", icon="X")
+
+    elif updater.include_branches and \
+            len(updater.tags) == len(updater.include_branch_list) and not \
+            updater.manual_only:
+        # No releases found, but still show the appropriate branch.
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        update_now_txt = "Update directly to {}".format(
+            updater.include_branch_list[0])
+        split.operator(AddonUpdaterUpdateNow.bl_idname, text=update_now_txt)
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
+
+    elif updater.update_ready and not updater.manual_only:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterUpdateNow.bl_idname,
+                       text="Update now to " + str(updater.update_version))
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
+
+    elif updater.update_ready and updater.manual_only:
+        col.scale_y = 2
+        dl_now_txt = "Download " + str(updater.update_version)
+        col.operator("wm.url_open",
+                     text=dl_now_txt).url = updater.website
+    else:  # i.e. that updater.update_ready == False.
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="Addon is up to date")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
+
+    if not updater.manual_only:
+        col = row.column(align=True)
+        if updater.include_branches and len(updater.include_branch_list) > 0:
+            branch = updater.include_branch_list[0]
+            col.operator(AddonUpdaterUpdateTarget.bl_idname,
+                         text="Install {} / old version".format(branch))
+        else:
+            col.operator(AddonUpdaterUpdateTarget.bl_idname,
+                         text="(Re)install addon version")
+        last_date = "none found"
+        backup_path = os.path.join(updater.stage_path, "backup")
+        if "backup_date" in updater.json and os.path.isdir(backup_path):
+            if updater.json["backup_date"] == "":
+                last_date = "Date not found"
+            else:
+                last_date = updater.json["backup_date"]
+        backup_text = "Restore addon backup ({})".format(last_date)
+        col.operator(AddonUpdaterRestoreBackup.bl_idname, text=backup_text)
+
+    row = box.row()
+    row.scale_y = 0.7
+    last_check = updater.json["last_check"]
+    if updater.error is not None and updater.error_msg is not None:
+        row.label(text=updater.error_msg)
+    elif last_check:
+        last_check = last_check[0: last_check.index(".")]
+        row.label(text="Last update check: " + last_check)
+    else:
+        row.label(text="Last update check: Never")
+
+
+def update_settings_ui_condensed(self, context, element=None):
+    """Preferences - Condensed drawing within preferences.
+
+    Alternate draw for user preferences or other places, does not draw a box.
+    """
+
+    # Element is a UI element, such as layout, a row, column, or box.
+    if element is None:
+        element = self.layout
+    row = element.row()
+
+    # In case of error importing updater.
+    if updater.invalid_updater:
+        row.label(text="Error initializing updater code:")
+        row.label(text=updater.error_msg)
+        return
+    settings = get_user_preferences(context)
+    if not settings:
+        row.label(text="Error getting updater preferences", icon='ERROR')
+        return
+
+    # Special case to tell user to restart blender, if set that way.
+    if not updater.auto_reload_post_update:
+        saved_state = updater.json
+        if "just_updated" in saved_state and saved_state["just_updated"]:
+            row.alert = True  # mark red
+            row.operator(
+                "wm.quit_blender",
+                text="Restart blender to complete update",
+                icon="ERROR")
+            return
+
+    col = row.column()
+    if updater.error is not None:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        if "ssl" in updater.error_msg.lower():
+            split.enabled = True
+            split.operator(AddonUpdaterInstallManually.bl_idname,
+                           text=updater.error)
+        else:
+            split.enabled = False
+            split.operator(AddonUpdaterCheckNow.bl_idname,
+                           text=updater.error)
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
+
+    elif updater.update_ready is None and not updater.async_checking:
+        col.scale_y = 2
+        col.operator(AddonUpdaterCheckNow.bl_idname)
+    elif updater.update_ready is None:  # Async is running.
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="Checking...")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterEndBackground.bl_idname, text="", icon="X")
+
+    elif updater.include_branches and \
+            len(updater.tags) == len(updater.include_branch_list) and not \
+            updater.manual_only:
+        # No releases found, but still show the appropriate branch.
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        now_txt = "Update directly to " + str(updater.include_branch_list[0])
+        split.operator(AddonUpdaterUpdateNow.bl_idname, text=now_txt)
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
+
+    elif updater.update_ready and not updater.manual_only:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterUpdateNow.bl_idname,
+                       text="Update now to " + str(updater.update_version))
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
+
+    elif updater.update_ready and updater.manual_only:
+        col.scale_y = 2
+        dl_txt = "Download " + str(updater.update_version)
+        col.operator("wm.url_open", text=dl_txt).url = updater.website
+    else:  # i.e. that updater.update_ready == False.
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="Addon is up to date")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
+
+    row = element.row()
+    row.prop(settings, "auto_check_update")
+
+    row = element.row()
+    row.scale_y = 0.7
+    last_check = updater.json["last_check"]
+    if updater.error is not None and updater.error_msg is not None:
+        row.label(text=updater.error_msg)
+    elif last_check != "" and last_check is not None:
+        last_check = last_check[0: last_check.index(".")]
+        row.label(text="Last check: " + last_check)
+    else:
+        row.label(text="Last check: Never")
+
+
+def skip_tag_function(self, tag):
+    """A global function for tag skipping.
+
+    A way to filter which tags are displayed, e.g. to limit downgrading too
+    long ago.
+
+    Args:
+        self: The instance of the singleton addon update.
+        tag: the text content of a tag from the repo, e.g. "v1.2.3".
+
+    Returns:
+        bool: True to skip this tag name (ie don't allow for downloading this
+            version), or False if the tag is allowed.
+    """
+
+    # In case of error importing updater.
+    if self.invalid_updater:
+        return False
+
+    # ---- write any custom code here, return true to disallow version ---- #
+    #
+    # # Filter out e.g. if 'beta' is in name of release
+    # if 'beta' in tag.lower():
+    # 	return True
+    # ---- write any custom code above, return true to disallow version --- #
+
+    if self.include_branches:
+        for branch in self.include_branch_list:
+            if tag["name"].lower() == branch:
+                return False
+
+    # Function converting string to tuple, ignoring e.g. leading 'v'.
+    # Be aware that this strips out other text that you might otherwise
+    # want to be kept and accounted for when checking tags (e.g. v1.1a vs 1.1b)
+    tupled = self.version_tuple_from_text(tag["name"])
+    if not isinstance(tupled, tuple):
+        return True
+
+    # Select the min tag version - change tuple accordingly.
+    if self.version_min_update is not None:
+        if tupled < self.version_min_update:
+            return True  # Skip if current version below this.
+
+    # Select the max tag version.
+    if self.version_max_update is not None:
+        if tupled >= self.version_max_update:
+            return True  # Skip if current version at or above this.
+
+    # In all other cases, allow showing the tag for updating/reverting.
+    # To simply and always show all tags, this return False could be moved
+    # to the start of the function definition so all tags are allowed.
+    return False
+
+
+def select_link_function(self, tag):
+    """Only customize if trying to leverage "attachments" in *GitHub* releases.
+
+    A way to select from one or multiple attached downloadable files from the
+    server, instead of downloading the default release/tag source code.
+    """
+
+    # -- Default, universal case (and is the only option for GitLab/Bitbucket)
+    link = tag["zipball_url"]
+
+    # -- Example: select the first (or only) asset instead source code --
+    # if "assets" in tag and "browser_download_url" in tag["assets"][0]:
+    # 	link = tag["assets"][0]["browser_download_url"]
+
+    # -- Example: select asset based on OS, where multiple builds exist --
+    # # not tested/no error checking, modify to fit your own needs!
+    # # assume each release has three attached builds:
+    # #		release_windows.zip, release_OSX.zip, release_linux.zip
+    # # This also would logically not be used with "branches" enabled
+    # if platform.system() == "Darwin": # ie OSX
+    # 	link = [asset for asset in tag["assets"] if 'OSX' in asset][0]
+    # elif platform.system() == "Windows":
+    # 	link = [asset for asset in tag["assets"] if 'windows' in asset][0]
+    # elif platform.system() == "Linux":
+    # 	link = [asset for asset in tag["assets"] if 'linux' in asset][0]
+
+    return link
+
+
+# -----------------------------------------------------------------------------
+# Register, should be run in the register module itself
+# -----------------------------------------------------------------------------
+classes = (
+    AddonUpdaterInstallPopup,
+    AddonUpdaterCheckNow,
+    AddonUpdaterUpdateNow,
+    AddonUpdaterUpdateTarget,
+    AddonUpdaterInstallManually,
+    AddonUpdaterUpdatedSuccessful,
+    AddonUpdaterRestoreBackup,
+    AddonUpdaterIgnore,
+    AddonUpdaterEndBackground
+)
+
+
+def register(bl_info):
+    """Registering the operators in this module"""
+    # Safer failure in case of issue loading module.
+    if updater.error:
+        print("Exiting updater registration, " + updater.error)
+        return
+    updater.clear_state()  # Clear internal vars, avoids reloading oddities.
+
+    # Confirm your updater "engine" (Github is default if not specified).
+    updater.engine = "Github"
+    # updater.engine = "GitLab"
+    # updater.engine = "Bitbucket"
+
+    # If using private repository, indicate the token here.
+    # Must be set after assigning the engine.
+    # **WARNING** Depending on the engine, this token can act like a password!!
+    # Only provide a token if the project is *non-public*, see readme for
+    # other considerations and suggestions from a security standpoint.
+    updater.private_token = None  # "tokenstring"
+
+    # Choose your own username, must match website (not needed for GitLab).
+    updater.user = "cgcookie"
+
+    # Choose your own repository, must match git name for GitHUb and Bitbucket,
+    # for GitLab use project ID (numbers only).
+    updater.repo = "blender-addon-updater"
+
+    # updater.addon = # define at top of module, MUST be done first
+
+    # Website for manual addon download, optional but recommended to set.
+    updater.website = "https://github.com/CGCookie/blender-addon-updater/"
+
+    # Addon subfolder path.
+    # "sample/path/to/addon"
+    # default is "" or None, meaning root
+    updater.subfolder_path = ""
+
+    # Used to check/compare versions.
+    updater.current_version = bl_info["version"]
+
+    # Optional, to hard-set update frequency, use this here - however, this
+    # demo has this set via UI properties.
+    # updater.set_check_interval(enabled=False, months=0, days=0, hours=0, minutes=2)
+
+    # Optional, consider turning off for production or allow as an option
+    # This will print out additional debugging info to the console
+    updater.verbose = True  # make False for production default
+
+    # Optional, customize where the addon updater processing subfolder is,
+    # essentially a staging folder used by the updater on its own
+    # Needs to be within the same folder as the addon itself
+    # Need to supply a full, absolute path to folder
+    # updater.updater_path = # set path of updater folder, by default:
+    # 			/addons/{__package__}/{__package__}_updater
+
+    # Auto create a backup of the addon when installing other versions.
+    updater.backup_current = True  # True by default
+
+    # Sample ignore patterns for when creating backup of current during update.
+    updater.backup_ignore_patterns = ["__pycache__"]
+    # Alternate example patterns:
+    # updater.backup_ignore_patterns = [".git", "__pycache__", "*.bat", ".gitignore", "*.exe"]
+
+    # Patterns for files to actively overwrite if found in new update file and
+    # are also found in the currently installed addon. Note that by default
+    # (ie if set to []), updates are installed in the same way as blender:
+    # .py files are replaced, but other file types (e.g. json, txt, blend)
+    # will NOT be overwritten if already present in current install. Thus
+    # if you want to automatically update resources/non py files, add them as a
+    # part of the pattern list below so they will always be overwritten by an
+    # update. If a pattern file is not found in new update, no action is taken
+    # NOTE: This does NOT delete anything proactively, rather only defines what
+    # is allowed to be overwritten during an update execution.
+    updater.overwrite_patterns = ["*.png", "*.jpg", "README.md", "LICENSE.txt"]
+    # updater.overwrite_patterns = []
+    # other examples:
+    # ["*"] means ALL files/folders will be overwritten by update, was the
+    #    behavior pre updater v1.0.4.
+    # [] or ["*.py","*.pyc"] matches default blender behavior, ie same effect
+    #    if user installs update manually without deleting the existing addon
+    #    first e.g. if existing install and update both have a resource.blend
+    #    file, the existing installed one will remain.
+    # ["some.py"] means if some.py is found in addon update, it will overwrite
+    #    any existing some.py in current addon install, if any.
+    # ["*.json"] means all json files found in addon update will overwrite
+    #    those of same name in current install.
+    # ["*.png","README.md","LICENSE.txt"] means the readme, license, and all
+    #    pngs will be overwritten by update.
+
+    # Patterns for files to actively remove prior to running update.
+    # Useful if wanting to remove old code due to changes in filenames
+    # that otherwise would accumulate. Note: this runs after taking
+    # a backup (if enabled) but before placing in new update. If the same
+    # file name removed exists in the update, then it acts as if pattern
+    # is placed in the overwrite_patterns property. Note this is effectively
+    # ignored if clean=True in the run_update method.
+    updater.remove_pre_update_patterns = ["*.py", "*.pyc"]
+    # Note setting ["*"] here is equivalent to always running updates with
+    # clean = True in the run_update method, ie the equivalent of a fresh,
+    # new install. This would also delete any resources or user-made/modified
+    # files setting ["__pycache__"] ensures the pycache folder always removed.
+    # The configuration of ["*.py", "*.pyc"] is a safe option as this
+    # will ensure no old python files/caches remain in event different addon
+    # versions have different filenames or structures.
+
+    # Allow branches like 'master' as an option to update to, regardless
+    # of release or version.
+    # Default behavior: releases will still be used for auto check (popup),
+    # but the user has the option from user preferences to directly
+    # update to the master branch or any other branches specified using
+    # the "install {branch}/older version" operator.
+    updater.include_branches = True
+
+    # (GitHub only) This options allows using "releases" instead of "tags",
+    # which enables pulling down release logs/notes, as well as installs update
+    # from release-attached zips (instead of the auto-packaged code generated
+    # with a release/tag). Setting has no impact on BitBucket or GitLab repos.
+    updater.use_releases = False
+    # Note: Releases always have a tag, but a tag may not always be a release.
+    # Therefore, setting True above will filter out any non-annotated tags.
+    # Note 2: Using this option will also display (and filter by) the release
+    # name instead of the tag name, bear this in mind given the
+    # skip_tag_function filtering above.
+
+    # Populate if using "include_branches" option above.
+    # Note: updater.include_branch_list defaults to ['master'] branch if set to
+    # none. Example targeting another multiple branches allowed to pull from:
+    # updater.include_branch_list = ['master', 'dev']
+    updater.include_branch_list = None  # None is the equivalent = ['master']
+
+    # Only allow manual install, thus prompting the user to open
+    # the addon's web page to download, specifically: updater.website
+    # Useful if only wanting to get notification of updates but not
+    # directly install.
+    updater.manual_only = False
+
+    # Used for development only, "pretend" to install an update to test
+    # reloading conditions.
+    updater.fake_install = False  # Set to true to test callback/reloading.
+
+    # Show popups, ie if auto-check for update is enabled or a previous
+    # check for update in user preferences found a new version, show a popup
+    # (at most once per blender session, and it provides an option to ignore
+    # for future sessions); default behavior is set to True.
+    updater.show_popups = True
+    # note: if set to false, there will still be an "update ready" box drawn
+    # using the `update_notice_box_ui` panel function.
+
+    # Override with a custom function on what tags
+    # to skip showing for updater; see code for function above.
+    # Set the min and max versions allowed to install.
+    # Optional, default None
+    # min install (>=) will install this and higher
+    updater.version_min_update = (0, 0, 0)
+    # updater.version_min_update = None  # None or default for no minimum.
+
+    # Max install (<) will install strictly anything lower than this version
+    # number, useful to limit the max version a given user can install (e.g.
+    # if support for a future version of blender is going away, and you don't
+    # want users to be prompted to install a non-functioning addon)
+    # updater.version_max_update = (9,9,9)
+    updater.version_max_update = None  # None or default for no max.
+
+    # Function defined above, customize as appropriate per repository
+    updater.skip_tag = skip_tag_function  # min and max used in this function
+
+    # Function defined above, optionally customize as needed per repository.
+    updater.select_link = select_link_function
+
+    # Recommended false to encourage blender restarts on update completion
+    # Setting this option to True is NOT as stable as false (could cause
+    # blender crashes).
+    updater.auto_reload_post_update = False
+
+    # The register line items for all operators/panels.
+    # If using bpy.utils.register_module(__name__) to register elsewhere
+    # in the addon, delete these lines (also from unregister).
+    for cls in classes:
+        # Apply annotations to remove Blender 2.8+ warnings, no effect on 2.7
+        make_annotations(cls)
+        # Comment out this line if using bpy.utils.register_module(__name__)
+        bpy.utils.register_class(cls)
+
+    # Special situation: we just updated the addon, show a popup to tell the
+    # user it worked. Could enclosed in try/catch in case other issues arise.
+    show_reload_popup()
+
+
+def unregister():
+    for cls in reversed(classes):
+        # Comment out this line if using bpy.utils.unregister_module(__name__).
+        bpy.utils.unregister_class(cls)
+
+    # Clear global vars since they may persist if not restarting blender.
+    updater.clear_state()  # Clear internal vars, avoids reloading oddities.
+
+    global ran_auto_check_install_popup
+    ran_auto_check_install_popup = False
+
+    global ran_update_success_popup
+    ran_update_success_popup = False
+
+    global ran_background_check
+    ran_background_check = False

--- a/addon/operators.py
+++ b/addon/operators.py
@@ -80,7 +80,7 @@ class OJ_OT_build(bpy.types.Operator):
         asset_dir = Path(settings.asset_dir)
         context.window.cursor_set('WAIT')
         try:
-            report = run_build(asset_dir, bpy)
+            report = run_build(asset_dir, bpy, packaging_mode=settings.packaging_mode)
         except Exception as exc:  # surface as an operator error, never crash
             self.report({'ERROR'}, "Build failed: {0}".format(exc))
             return {'CANCELLED'}

--- a/addon/prefs.py
+++ b/addon/prefs.py
@@ -1,8 +1,9 @@
 """Add-on preferences: override the pipeline output root."""
 
 import bpy
+from . import addon_updater_ops
 
-
+@addon_updater_ops.make_annotations
 class OJAddonPreferences(bpy.types.AddonPreferences):
     bl_idname = __package__
 
@@ -13,6 +14,39 @@ class OJAddonPreferences(bpy.types.AddonPreferences):
         default="",
     )
 
+    # addon updater preferences
+    auto_check_update: bpy.props.BoolProperty(
+        name="Auto-check for Update",
+        description="If enabled, auto-check for updates using an interval",
+        default=False)
+        
+    updater_interval_months: bpy.props.IntProperty(
+        name='Months',
+        description="Number of months between checking for updates",
+        default=0,
+        min=0)
+        
+    updater_interval_days: bpy.props.IntProperty(
+        name='Days',
+        description="Number of days between checking for updates",
+        default=7,
+        min=0,
+        max=31)
+        
+    updater_interval_hours: bpy.props.IntProperty(
+        name='Hours',
+        description="Number of hours between checking for updates",
+        default=0,
+        min=0,
+        max=23)
+        
+    updater_interval_minutes: bpy.props.IntProperty(
+        name='Minutes',
+        description="Number of minutes between checking for updates",
+        default=0,
+        min=0,
+        max=59)
+
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "output_dir")
@@ -20,3 +54,5 @@ class OJAddonPreferences(bpy.types.AddonPreferences):
             text="Blank = default <repo>/output (or an existing OPEN_JAYWALKER_OUTPUT_ROOT).",
             icon='INFO',
         )
+        
+        addon_updater_ops.update_settings_ui(self, context)

--- a/addon/state.py
+++ b/addon/state.py
@@ -17,3 +17,16 @@ class OJSettings(bpy.types.PropertyGroup):
     character_ids_csv: bpy.props.StringProperty(default="")
     is_crowd: bpy.props.BoolProperty(default=False)
     character_count: bpy.props.IntProperty(default=0)
+    packaging_mode: bpy.props.EnumProperty(
+        name="Output",
+        description="How to package the generated ASAM human(s)",
+        items=[
+            ("inplace_export", "In-place + export .blend",
+             "Build in this file, then export only the ASAM result to <asset>_asam.blend"),
+            ("inplace_only", "In-place only",
+             "Build in this file; do not export a separate .blend"),
+            ("separate_only", "Separate file only",
+             "Export the ASAM result, then remove generated data from this file"),
+        ],
+        default="inplace_export",
+    )

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -69,6 +69,7 @@ class OJ_PT_panel(bpy.types.Panel):
                         icon='CHECKMARK',
                     )
 
+            layout.prop(s, "packaging_mode")
             build_row = layout.row()
             build_row.enabled = s.has_plan and not s.built
             build_row.operator("open_jaywalker.build", icon='MOD_ARMATURE')

--- a/src/armature_inspector/inspector.py
+++ b/src/armature_inspector/inspector.py
@@ -702,7 +702,7 @@ def _infer_axis_metadata_from_bones(bones_data):
 
 
 def _build_bbox_metadata(points, axis_metadata):
-    """Build bounding box metadata from local-space points."""
+    """Build bounding box metadata from world-space points."""
     if not points:
         zero = [0.0, 0.0, 0.0]
         return {
@@ -735,7 +735,7 @@ def build_armature_placement_metadata(bones_data, mesh_points=None, driven_meshe
 
     Args:
         bones_data: List of exported bone payloads.
-        mesh_points: Optional list of local-space mesh bound-box corner points.
+        mesh_points: Optional list of world-space mesh bound-box corner points.
         driven_meshes: Optional list of mesh object names contributing to the bounds.
 
     Returns:

--- a/src/armature_inspector/inspector.py
+++ b/src/armature_inspector/inspector.py
@@ -787,6 +787,15 @@ def _meshes_driven_by_armature(armature_obj):
     return list(meshes_by_id.values())
 
 
+def _mesh_world_bbox(obj):
+    """Axis-aligned world bbox of a single mesh object as {'min': [...], 'max': [...]}."""
+    from mathutils import Vector
+    corners = [obj.matrix_world @ Vector(c) for c in obj.bound_box]
+    mins = [min(c[i] for c in corners) for i in range(3)]
+    maxs = [max(c[i] for c in corners) for i in range(3)]
+    return {"min": [float(v) for v in mins], "max": [float(v) for v in maxs]}
+
+
 def _collect_armature_mesh_bounds(armature_obj):
     """Collect driven-mesh bound-box corners in WORLD coordinates."""
     from mathutils import Vector
@@ -902,6 +911,7 @@ def build_mesh_binding(armature_obj):
                     "per_group": per_group_stats,
                 },
                 "material_slots": material_slots,
+                "bbox": _mesh_world_bbox(obj),
                 "warnings": sorted(warnings),
             }
         )

--- a/src/armature_inspector/inspector.py
+++ b/src/armature_inspector/inspector.py
@@ -515,21 +515,33 @@ def print_detected_chains(armature_obj):
 # region BONE GEOMETRY EXTRACTION
 
 
-def extract_bone_geometry(bone):
-    """
-    Extract geometry and basic transform data from a single bone.
+def extract_bone_geometry(bone, matrix_world=None):
+    """Extract geometry/transform for a single bone in WORLD coordinates.
+
+    head/tail are expressed in world space (matrix_world @ head_local). For an
+    identity-transform armature this equals the armature-local value, so existing
+    single-character outputs are unchanged.
 
     Args:
         bone: A Blender bone (bpy.types.Bone)
+        matrix_world: Optional armature world matrix. When provided, bone
+                      head/tail are transformed into world coordinates.
 
     Returns:
         dict: Geometry data for the bone.
     """
+    head_local = bone.head_local
+    tail_local = bone.tail_local
+    if matrix_world is not None:
+        head = matrix_world @ head_local
+        tail = matrix_world @ tail_local
+    else:
+        head, tail = head_local, tail_local
     return {
         "name": bone.name,
         "parent": bone.parent.name if bone.parent else None,
-        "head": tuple(bone.head_local),
-        "tail": tuple(bone.tail_local),
+        "head": (float(head[0]), float(head[1]), float(head[2])),
+        "tail": (float(tail[0]), float(tail[1]), float(tail[2])),
         "length": float(bone.length),
         "matrix_local": [list(row) for row in bone.matrix_local],
     }
@@ -537,21 +549,22 @@ def extract_bone_geometry(bone):
 
 def extract_armature_geometry(armature_obj, prefix_filter=None):
     """
-    Extract geometry data for all bones in an armature.
+    Extract geometry data for all bones in an armature in WORLD coordinates.
 
     Args:
         armature_obj: Blender armature object (bpy.types.Object)
         prefix_filter: Optional prefix to restrict bones (e.g., 'DEF-')
 
     Returns:
-        list[dict]: Geometry data for each bone.
+        list[dict]: Geometry data for each bone with head/tail in world space.
     """
     bones = armature_obj.data.bones
+    matrix_world = getattr(armature_obj, "matrix_world", None)
     result = []
     for bone in bones:
         if prefix_filter is not None and not bone.name.startswith(prefix_filter):
             continue
-        result.append(extract_bone_geometry(bone))
+        result.append(extract_bone_geometry(bone, matrix_world))
     return result
 
 

--- a/src/armature_inspector/inspector.py
+++ b/src/armature_inspector/inspector.py
@@ -788,23 +788,17 @@ def _meshes_driven_by_armature(armature_obj):
 
 
 def _collect_armature_mesh_bounds(armature_obj):
-    """
-    Collect mesh bound-box corner points in armature-local coordinates.
-    """
+    """Collect driven-mesh bound-box corners in WORLD coordinates."""
     from mathutils import Vector
 
-    armature_inverse = armature_obj.matrix_world.inverted()
     driven_meshes = []
-    local_points = []
-
+    world_points = []
     for obj in _meshes_driven_by_armature(armature_obj):
         driven_meshes.append(obj.name)
         for corner in obj.bound_box:
             world_point = obj.matrix_world @ Vector(corner)
-            local_point = armature_inverse @ world_point
-            local_points.append([float(local_point[0]), float(local_point[1]), float(local_point[2])])
-
-    return local_points, driven_meshes
+            world_points.append([float(world_point[0]), float(world_point[1]), float(world_point[2])])
+    return world_points, driven_meshes
 
 
 def build_mesh_binding(armature_obj):

--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -95,6 +95,12 @@ def build_armature_in_blender(build_spec: dict, bpy_module=None, parent_collecti
     )
     armature_object = _create_armature_object(bpy_module, armature_name, asset_name, collection, group_root)
     _populate_edit_bones(bpy_module, armature_object, build_spec["bones"])
+    # Force the dependency graph to evaluate the just-placed Grp_Root/armature so the
+    # duplicated meshes below are positioned against their parent's CURRENT world
+    # transform. Without this, Blender's lazy depsgraph can leave the armature's
+    # matrix_world stale (still at the pre-placement origin) when _copy_mesh_object
+    # sets each mesh's matrix_world, leaving the body behind while the rig moved.
+    _refresh_depsgraph(bpy_module)
     mesh_result = _duplicate_bound_meshes(
         bpy_module,
         build_spec,
@@ -444,6 +450,17 @@ def _copy_mesh_object(
     collection.objects.link(generated_mesh)
     # Parent to the generated armature (one level below group_root) to match ASAM hierarchy.
     generated_mesh.parent = parent_object
+    # Pin the parent-inverse to the parent's CURRENT world matrix so the duplicate keeps
+    # its source world transform regardless of where the parent (a relocated armature
+    # under Grp_Root) now sits. Setting matrix_world alone is not enough: Blender derives
+    # matrix_basis from parent.matrix_world @ matrix_parent_inverse, and a stale/identity
+    # parent-inverse against a moved parent shifts the body off its rig.
+    parent_world = getattr(parent_object, "matrix_world", None)
+    if parent_world is not None and hasattr(generated_mesh, "matrix_parent_inverse"):
+        try:
+            generated_mesh.matrix_parent_inverse = parent_world.inverted()
+        except (AttributeError, ValueError):
+            pass
     if world_matrix is not None:
         generated_mesh.matrix_world = world_matrix
     return generated_mesh
@@ -534,6 +551,25 @@ def _ensure_object_mode(bpy_module) -> None:
         return
     if getattr(active_object, "mode", "OBJECT") != "OBJECT":
         bpy_module.ops.object.mode_set(mode="OBJECT")
+
+
+def _refresh_depsgraph(bpy_module) -> None:
+    """Re-evaluate object world matrices after a transform change.
+
+    Blender's dependency graph is lazy: after setting Grp_Root.location and parenting
+    the armature, the armature's matrix_world may still report its pre-placement value
+    until the view layer is updated. Meshes positioned before this update would be
+    placed against a stale parent transform. No-op (and safely ignored) under the
+    test fake bpy, which has no view_layer.update.
+    """
+    context = getattr(bpy_module, "context", None)
+    view_layer = getattr(context, "view_layer", None) if context is not None else None
+    update = getattr(view_layer, "update", None) if view_layer is not None else None
+    if callable(update):
+        try:
+            update()
+        except (RuntimeError, AttributeError):
+            pass
 
 
 def build_crowd_in_blender(

--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -86,9 +86,11 @@ def build_armature_in_blender(build_spec: dict, bpy_module=None, parent_collecti
         armature_name,
     )
     collection = _create_collection(bpy_module, collection_name, asset_name, parent_collection)
-    grp_root_local_origin = build_spec.get("grp_root_local_origin", [0.0, 0.0, 0.0])
+    grp_root_location = build_spec.get(
+        "grp_root_world_location", build_spec.get("grp_root_local_origin", [0.0, 0.0, 0.0])
+    )
     group_root = _create_group_root(
-        bpy_module, group_root_name, asset_name, collection, grp_root_local_origin
+        bpy_module, group_root_name, asset_name, collection, grp_root_location
     )
     armature_object = _create_armature_object(bpy_module, armature_name, asset_name, collection, group_root)
     _populate_edit_bones(bpy_module, armature_object, build_spec["bones"])

--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -97,10 +97,13 @@ def build_armature_in_blender(build_spec: dict, bpy_module=None, parent_collecti
     _populate_edit_bones(bpy_module, armature_object, build_spec["bones"])
     # Force the dependency graph to evaluate the just-placed Grp_Root/armature so the
     # duplicated meshes below are positioned against their parent's CURRENT world
-    # transform. Without this, Blender's lazy depsgraph can leave the armature's
-    # matrix_world stale (still at the pre-placement origin) when _copy_mesh_object
-    # sets each mesh's matrix_world, leaving the body behind while the rig moved.
+    # transform.
     _refresh_depsgraph(bpy_module)
+    # The rig was relocated from the source bones (grp_root_local_origin) to the body
+    # anchor (grp_root_world_location). The bound mesh deforms to the source bone frame,
+    # so it must be translated by the SAME delta to travel with its rig. For single
+    # characters the two anchors coincide -> delta is zero -> mesh keeps source world.
+    placement_delta = _placement_delta(build_spec)
     mesh_result = _duplicate_bound_meshes(
         bpy_module,
         build_spec,
@@ -108,6 +111,7 @@ def build_armature_in_blender(build_spec: dict, bpy_module=None, parent_collecti
         source_armature,
         armature_object,
         character_prefix,
+        placement_delta,
     )
 
     hidden_source_objects = _hide_source_objects(bpy_module, source_armature, build_spec)
@@ -342,6 +346,7 @@ def _duplicate_bound_meshes(
     source_armature,
     generated_armature,
     character_prefix=None,
+    placement_delta=(0.0, 0.0, 0.0),
 ) -> dict:
     duplicated_meshes = []
     skipped_meshes = []
@@ -370,6 +375,7 @@ def _duplicate_bound_meshes(
             build_spec["asset_name"],
             collection,
             generated_armature,
+            placement_delta,
         )
         retargeted = _retarget_armature_modifiers(generated_mesh, source_armature, generated_armature)
         if record.get("armature_link") == "parent" and not retargeted:
@@ -425,12 +431,16 @@ def _copy_mesh_object(
     asset_name: str,
     collection,
     parent_object,
+    placement_delta=(0.0, 0.0, 0.0),
 ):
-    """Duplicate a mesh object and parent it to parent_object.
+    """Duplicate a mesh object, parent it to parent_object, and place it on its rig.
 
-    The source mesh's ``matrix_world`` is preserved on the duplicate; Blender's
-    parent-inverse handles the rebase into Grp_Root-local space when the
-    generated armature (a descendant of Grp_Root) becomes the parent.
+    The duplicate keeps the source mesh's ``matrix_world`` translated by
+    ``placement_delta`` -- the same offset the rig was relocated by
+    (grp_root_world_location - grp_root_local_origin). The bound mesh deforms into the
+    source bone frame, so applying the identical delta makes the body travel with its
+    rig. ``placement_delta`` is zero for single-character builds, so the duplicate keeps
+    the source world transform unchanged.
     """
     generated_mesh = source_mesh.copy()
     generated_mesh.name = _resolve_unique_name(
@@ -450,20 +460,27 @@ def _copy_mesh_object(
     collection.objects.link(generated_mesh)
     # Parent to the generated armature (one level below group_root) to match ASAM hierarchy.
     generated_mesh.parent = parent_object
-    # Pin the parent-inverse to the parent's CURRENT world matrix so the duplicate keeps
-    # its source world transform regardless of where the parent (a relocated armature
-    # under Grp_Root) now sits. Setting matrix_world alone is not enough: Blender derives
-    # matrix_basis from parent.matrix_world @ matrix_parent_inverse, and a stale/identity
-    # parent-inverse against a moved parent shifts the body off its rig.
-    parent_world = getattr(parent_object, "matrix_world", None)
-    if parent_world is not None and hasattr(generated_mesh, "matrix_parent_inverse"):
-        try:
-            generated_mesh.matrix_parent_inverse = parent_world.inverted()
-        except (AttributeError, ValueError):
-            pass
     if world_matrix is not None:
-        generated_mesh.matrix_world = world_matrix
+        generated_mesh.matrix_world = _translated_matrix(world_matrix, placement_delta)
     return generated_mesh
+
+
+def _translated_matrix(matrix, delta):
+    """Return ``matrix`` with ``delta`` added to its translation.
+
+    No-op (returns the matrix unchanged) when delta is zero or when the matrix does not
+    support translation arithmetic (the pure-Python test fake). Only the live Blender
+    path with a real mathutils matrix and a non-zero delta takes the translation branch.
+    """
+    if not any(abs(float(d)) > 1e-9 for d in delta):
+        return matrix
+    try:
+        from mathutils import Vector  # Blender-only; only reached when delta != 0.
+        moved = matrix.copy()
+        moved.translation = moved.translation + Vector((float(delta[0]), float(delta[1]), float(delta[2])))
+        return moved
+    except (ImportError, AttributeError, TypeError):
+        return matrix
 
 
 def _retarget_armature_modifiers(mesh_obj, source_armature, generated_armature) -> List[str]:
@@ -551,6 +568,18 @@ def _ensure_object_mode(bpy_module) -> None:
         return
     if getattr(active_object, "mode", "OBJECT") != "OBJECT":
         bpy_module.ops.object.mode_set(mode="OBJECT")
+
+
+def _placement_delta(build_spec: dict) -> List[float]:
+    """Vector the rig was relocated by: grp_root_world_location - grp_root_local_origin.
+
+    Zero for single-character builds (the two anchors coincide), so the bound mesh keeps
+    its source world transform. Non-zero for relocated crowd characters, moving the body
+    onto its rig.
+    """
+    world = build_spec.get("grp_root_world_location") or build_spec.get("grp_root_local_origin") or [0.0, 0.0, 0.0]
+    local = build_spec.get("grp_root_local_origin") or [0.0, 0.0, 0.0]
+    return [float(world[i]) - float(local[i]) for i in range(3)]
 
 
 def _refresh_depsgraph(bpy_module) -> None:

--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import List, Optional
 
 try:
@@ -609,3 +610,24 @@ def _remove_generated_crowd_wrapper(bpy_module, wrapper_name: str, asset_name: s
         if scene.collection.children.get(wrapper.name) is not None:
             scene.collection.children.unlink(wrapper)
     bpy_module.data.collections.remove(wrapper)
+
+
+def export_generated_blend(bpy_module, wrapper_collection_name: str, filepath: str) -> str:
+    """Write ONLY the generated wrapper collection (and what it references) to a .blend.
+
+    The source rig/meshes are excluded: bpy.data.libraries.write serializes the given
+    datablocks plus their dependencies, not the whole file. Returns the written path.
+    Raises ValueError if the wrapper is absent or not a generated collection.
+    """
+    wrapper = bpy_module.data.collections.get(wrapper_collection_name)
+    if wrapper is None or not bool(wrapper.get(GENERATED_MARKER_KEY)):
+        raise ValueError(
+            "Refusing to export '{0}': not a generated wrapper collection".format(
+                wrapper_collection_name
+            )
+        )
+    directory = os.path.dirname(filepath)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    bpy_module.data.libraries.write(filepath, {wrapper}, fake_user=True)
+    return filepath

--- a/src/asam_human_builder/build_runner.py
+++ b/src/asam_human_builder/build_runner.py
@@ -20,11 +20,21 @@ from asam_human_builder.builder import (
 from asam_human_builder.blender_builder import (
     build_armature_in_blender,
     build_crowd_in_blender,
+    export_generated_blend,
+    purge_previous_generated_artifacts,
 )
 
 
-def run_build(asset_dir, bpy) -> dict:
+def run_build(asset_dir, bpy, packaging_mode="inplace_export") -> dict:
     """Resolve specs for asset_dir and build them (single or crowd).
+
+    packaging_mode controls post-build export:
+      "inplace_export" (default): build in place, then export generated wrapper
+          collection to <asset_dir>/<asset_name>_asam.blend.
+      "inplace_only": build only, no export.
+      "separate_only": export, then purge generated data from the open file.
+
+    Export failures are recorded on the report and never abort the in-place build.
 
     Returns the builder report (single) or crowd builder report (crowd).
     """
@@ -46,11 +56,35 @@ def run_build(asset_dir, bpy) -> dict:
             crowd_execution,
         )
         _, report_path = write_crowd_builder_report(asset_dir, report)
+        wrapper_name = resolved["wrapper_collection_name"]
     else:
         build_spec = resolved["specs"][0]
         execution_result = build_armature_in_blender(build_spec, bpy)
         report, report_path = write_builder_report(asset_dir, build_spec, execution_result)
         print_builder_summary(report, report_path)
+        wrapper_name = build_spec["generated_collection_name"]
+
+    _export_if_requested(asset_dir, resolved["asset_name"], wrapper_name, bpy, packaging_mode, report)
 
     print(success_message(report, report_path))
     return report
+
+
+def _export_if_requested(asset_dir, asset_name, wrapper_name, bpy, packaging_mode, report):
+    """inplace_only: no export. inplace_export/separate_only: write clean .blend;
+    separate_only also purges generated data from the open file. Export failures are
+    recorded on the report and never abort the in-place build."""
+    if packaging_mode == "inplace_only":
+        return
+    out_path = str(Path(asset_dir) / "{0}_asam.blend".format(asset_name))
+    try:
+        exported = export_generated_blend(bpy, wrapper_name, out_path)
+    except Exception as exc:  # never abort the in-place build
+        report["packaging_mode"] = packaging_mode
+        report["exported_blend_path"] = None
+        report["export_error"] = str(exc)
+        return
+    report["packaging_mode"] = packaging_mode
+    report["exported_blend_path"] = exported
+    if packaging_mode == "separate_only":
+        purge_previous_generated_artifacts(bpy)

--- a/src/asam_human_builder/build_runner.py
+++ b/src/asam_human_builder/build_runner.py
@@ -24,8 +24,15 @@ from asam_human_builder.blender_builder import (
     purge_previous_generated_artifacts,
 )
 
+# Output packaging modes. Shared canonical definition so the addon (Task C3) and the
+# builder reference the same literals instead of duplicating magic strings.
+PACKAGING_INPLACE_EXPORT = "inplace_export"
+PACKAGING_INPLACE_ONLY = "inplace_only"
+PACKAGING_SEPARATE_ONLY = "separate_only"
+PACKAGING_MODES = (PACKAGING_INPLACE_EXPORT, PACKAGING_INPLACE_ONLY, PACKAGING_SEPARATE_ONLY)
 
-def run_build(asset_dir, bpy, packaging_mode="inplace_export") -> dict:
+
+def run_build(asset_dir, bpy, packaging_mode=PACKAGING_INPLACE_EXPORT) -> dict:
     """Resolve specs for asset_dir and build them (single or crowd).
 
     packaging_mode controls post-build export:
@@ -71,20 +78,27 @@ def run_build(asset_dir, bpy, packaging_mode="inplace_export") -> dict:
 
 
 def _export_if_requested(asset_dir, asset_name, wrapper_name, bpy, packaging_mode, report):
-    """inplace_only: no export. inplace_export/separate_only: write clean .blend;
-    separate_only also purges generated data from the open file. Export failures are
-    recorded on the report and never abort the in-place build."""
-    if packaging_mode == "inplace_only":
+    """Record packaging outcome on the report and export when requested.
+
+    Modes:
+      - PACKAGING_INPLACE_ONLY: no export, no purge.
+      - PACKAGING_INPLACE_EXPORT: write the generated wrapper to a clean .blend.
+      - PACKAGING_SEPARATE_ONLY: export, then purge generated data from the open file.
+
+    `packaging_mode` is always recorded (even for inplace_only) so the report shape is
+    consistent across modes. Export failures are caught and recorded; they never abort
+    the already-completed in-place build.
+    """
+    report["packaging_mode"] = packaging_mode
+    report["exported_blend_path"] = None
+    report["export_error"] = None
+    if packaging_mode == PACKAGING_INPLACE_ONLY:
         return
     out_path = str(Path(asset_dir) / "{0}_asam.blend".format(asset_name))
     try:
-        exported = export_generated_blend(bpy, wrapper_name, out_path)
-    except Exception as exc:  # never abort the in-place build
-        report["packaging_mode"] = packaging_mode
-        report["exported_blend_path"] = None
+        report["exported_blend_path"] = export_generated_blend(bpy, wrapper_name, out_path)
+    except Exception as exc:  # never abort the already-completed in-place build
         report["export_error"] = str(exc)
         return
-    report["packaging_mode"] = packaging_mode
-    report["exported_blend_path"] = exported
-    if packaging_mode == "separate_only":
+    if packaging_mode == PACKAGING_SEPARATE_ONLY:
         purge_previous_generated_artifacts(bpy)

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -422,6 +422,8 @@ def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones:
             float(v)
             for v in root_resolution.get("grp_root_world_location", grp_root_local_origin)
         ],
+        "placement_mode": root_resolution.get("placement_mode", "source"),
+        "applied_grid_offset": root_resolution.get("applied_grid_offset"),
         "bones": [],
         "preserved_pelvis_pair": [],
         "warnings": [],
@@ -546,6 +548,9 @@ def build_builder_report(build_spec: dict, execution_result: dict) -> dict:
         "generated_armature_name": execution_result["generated_armature_name"],
         "collection_action": execution_result.get("collection_action"),
         "grp_root_local_origin": list(build_spec.get("grp_root_local_origin", [])),
+        "placement_mode": build_spec.get("placement_mode", "source"),
+        "grp_root_location": list(build_spec.get("grp_root_world_location", build_spec.get("grp_root_local_origin", []))),
+        "applied_grid_offset": build_spec.get("applied_grid_offset"),
         "root_mode": build_spec.get("root_resolution", {}).get("mode"),
         "preserved_source_root": preserved_source_root,
         "duplicated_meshes": copy.deepcopy(execution_result.get("duplicated_meshes", [])),

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -418,6 +418,10 @@ def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones:
         "mesh_binding": copy.deepcopy(build_plan["mesh_binding"]),
         "extras_preserved": copy.deepcopy(build_plan.get("extras_preserved", [])),
         "grp_root_local_origin": list(grp_root_local_origin),
+        "grp_root_world_location": [
+            float(v)
+            for v in root_resolution.get("grp_root_world_location", grp_root_local_origin)
+        ],
         "bones": [],
         "preserved_pelvis_pair": [],
         "warnings": [],

--- a/src/phase3_classifier/segmentation.py
+++ b/src/phase3_classifier/segmentation.py
@@ -7,6 +7,7 @@ Pure Python: operates on already-loaded inspector JSON dicts. No bpy.
 from __future__ import annotations
 
 import copy
+import math
 import re
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -283,6 +284,8 @@ def _assign_character_placements(reports):
     'source' when bodies are distributed; 'grid' when co-located. Anchors come from
     each character's owned mesh bboxes (body), falling back to the bone-derived
     bbox_ground_center when a character has no mesh.
+
+    Mutates the passed report dicts in place.
     """
     if not reports:
         return
@@ -332,7 +335,6 @@ def _character_footprint(placement, a, b):
 
 
 def _apply_grid(anchors, a, b):
-    import math
     count = len(anchors)
     columns = max(1, int(math.ceil(math.sqrt(count))))
     spacing = max(_character_footprint(p, a, b) for _r, _anc, p in anchors) * 1.5
@@ -375,6 +377,9 @@ def segment_recommended(asset_name: str, recommended_input) -> Optional[Segmenta
             report["review_flags"] = list(report["review_flags"]) + ["character_disconnected"]
         raw_reports.append((group, report))
 
+    # Mutates each report's root_resolution in place (grp_root_world_location +
+    # placement_mode); those dicts are the same objects _report_character/_plan_character
+    # snapshot below, so the placement keys flow into both outputs.
     _assign_character_placements([report for _g, report in raw_reports])
 
     report_characters: List[dict] = []

--- a/src/phase3_classifier/segmentation.py
+++ b/src/phase3_classifier/segmentation.py
@@ -257,6 +257,22 @@ def _plan_character(character_id: str, report: dict) -> dict:
     }
 
 
+def body_anchor_from_meshes(meshes, up_axis_index, up_sign):
+    """Ground-center of the union of owned meshes' world bboxes, or None if absent.
+
+    Planar axes use the bbox center; the up axis uses the ground (min when up_sign>=0,
+    else max) so the anchor sits on the floor under the body.
+    """
+    boxes = [m["bbox"] for m in (meshes or []) if isinstance(m.get("bbox"), dict)]
+    if not boxes:
+        return None
+    mins = [min(b["min"][i] for b in boxes) for i in range(3)]
+    maxs = [max(b["max"][i] for b in boxes) for i in range(3)]
+    center = [(mins[i] + maxs[i]) / 2.0 for i in range(3)]
+    center[up_axis_index] = mins[up_axis_index] if up_sign >= 0 else maxs[up_axis_index]
+    return [float(v) for v in center]
+
+
 def segment_recommended(asset_name: str, recommended_input) -> Optional[SegmentationResult]:
     """Return per-character decomposition for a crowd armature, or None if single."""
     bones = recommended_input.primary_data.get("bones", [])

--- a/src/phase3_classifier/segmentation.py
+++ b/src/phase3_classifier/segmentation.py
@@ -257,6 +257,10 @@ def _plan_character(character_id: str, report: dict) -> dict:
     }
 
 
+# Planar spread (metres) below which characters are treated as co-located and gridded.
+COLOCATED_SPREAD_THRESHOLD = 0.25
+
+
 def body_anchor_from_meshes(meshes, up_axis_index, up_sign):
     """Ground-center of the union of owned meshes' world bboxes, or None if absent.
 
@@ -271,6 +275,77 @@ def body_anchor_from_meshes(meshes, up_axis_index, up_sign):
     center = [(mins[i] + maxs[i]) / 2.0 for i in range(3)]
     center[up_axis_index] = mins[up_axis_index] if up_sign >= 0 else maxs[up_axis_index]
     return [float(v) for v in center]
+
+
+def _assign_character_placements(reports):
+    """Set root_resolution['grp_root_world_location'] and ['placement_mode'] per report.
+
+    'source' when bodies are distributed; 'grid' when co-located. Anchors come from
+    each character's owned mesh bboxes (body), falling back to the bone-derived
+    bbox_ground_center when a character has no mesh.
+    """
+    if not reports:
+        return
+    anchors = []
+    for report in reports:
+        placement = report["placement_metadata"]
+        up = placement["up_axis"]
+        anchor = body_anchor_from_meshes(
+            report["mesh_binding"].get("meshes"),
+            up_axis_index=int(up["index"]),
+            up_sign=int(up["sign"]),
+        )
+        if anchor is None:
+            anchor = [float(v) for v in placement["bbox_ground_center"]]
+            report["review_flags"] = list(report["review_flags"]) + ["character_without_mesh_anchor"]
+        anchors.append((report, anchor, placement))
+
+    forward_idx, side_idx = _planar_axes(anchors[0][2])
+    spread = _planar_spread(anchors, forward_idx, side_idx)
+
+    if spread <= COLOCATED_SPREAD_THRESHOLD:
+        _apply_grid(anchors, forward_idx, side_idx)
+    else:
+        for report, anchor, _placement in anchors:
+            report["root_resolution"]["grp_root_world_location"] = anchor
+            report["root_resolution"]["placement_mode"] = "source"
+
+
+def _planar_axes(placement):
+    up = int(placement["up_axis"]["index"])
+    others = [i for i in range(3) if i != up]
+    return others[0], others[1]
+
+
+def _planar_spread(anchors, a, b):
+    av = [anc[a] for _r, anc, _p in anchors]
+    bv = [anc[b] for _r, anc, _p in anchors]
+    return max(max(av) - min(av), max(bv) - min(bv))
+
+
+def _character_footprint(placement, a, b):
+    bbox_min = placement.get("bbox_min")
+    bbox_max = placement.get("bbox_max")
+    if not bbox_min or not bbox_max:
+        return 1.0
+    return max(abs(bbox_max[a] - bbox_min[a]), abs(bbox_max[b] - bbox_min[b]), 1e-3)
+
+
+def _apply_grid(anchors, a, b):
+    import math
+    count = len(anchors)
+    columns = max(1, int(math.ceil(math.sqrt(count))))
+    spacing = max(_character_footprint(p, a, b) for _r, _anc, p in anchors) * 1.5
+    for index, (report, anchor, _placement) in enumerate(anchors):
+        row, col = divmod(index, columns)
+        cell = list(anchor)
+        cell[a] = col * spacing
+        cell[b] = row * spacing
+        report["root_resolution"]["grp_root_world_location"] = [float(v) for v in cell]
+        report["root_resolution"]["placement_mode"] = "grid"
+        report["root_resolution"]["applied_grid_offset"] = [
+            float(cell[i] - anchor[i]) for i in range(3)
+        ]
 
 
 def segment_recommended(asset_name: str, recommended_input) -> Optional[SegmentationResult]:
@@ -290,8 +365,7 @@ def segment_recommended(asset_name: str, recommended_input) -> Optional[Segmenta
         recommended_input.armature_name,
     )
 
-    report_characters: List[dict] = []
-    plan_characters: List[dict] = []
+    raw_reports = []
     for group in groups:
         view = build_character_view(
             recommended_input.primary_data, group, per_char_binding.get(group.character_id)
@@ -299,6 +373,13 @@ def segment_recommended(asset_name: str, recommended_input) -> Optional[Segmenta
         report = classify_armature(asset_name, view)
         if not group.connected:
             report["review_flags"] = list(report["review_flags"]) + ["character_disconnected"]
+        raw_reports.append((group, report))
+
+    _assign_character_placements([report for _g, report in raw_reports])
+
+    report_characters: List[dict] = []
+    plan_characters: List[dict] = []
+    for group, report in raw_reports:
         report_characters.append(_report_character(group.character_id, report))
         plan_characters.append(_plan_character(group.character_id, report))
 

--- a/tests/blender_runbook/runbook_crowd_canonical.py
+++ b/tests/blender_runbook/runbook_crowd_canonical.py
@@ -1,0 +1,242 @@
+"""
+In-Blender crowd canonical-frame + placement runbook (Issue #49).
+
+Validates that a multi-character ("crowd") asset is built into N ASAM humans that are
+real-world metres, with each skeleton standing INSIDE its own body at the body's world
+location (or an auto-grid cell for co-located crowds) -- the fixes for the symptoms in
+issue #49 (rigs ~39x too large, perpendicular, all stacked at the origin while bodies
+sat tiny and scattered).
+
+Usage:
+  1. In VS Code: `Blender: Start` (launches Blender via the extension).
+  2. In Blender: File -> Open -> a crowd .blend (e.g. 1000idles.blend) whose armature
+     packs many prefixed characters under a shared root, with skinned body meshes.
+  3. In VS Code: open this file, then `Blender: Run Script`.
+
+This is NOT a pytest test: it requires an interactive Blender session and is not
+discovered by `python -m unittest`. It runs the inspector + classifier + crowd builder
+(via run_build with packaging_mode="inplace_only"), then asserts in-scene:
+
+  - each generated armature's world-space height is within tolerance of its paired body
+    mesh's world-space height (canonical metres; no ~39x discrepancy),
+  - each Grp_Root sits at the per-character placement location recorded in
+    builder_report.json (body anchor for distributed crowds, grid cell otherwise),
+  - each generated armature's world bbox-center is within roughly one body width of its
+    body mesh's world bbox-center (skeleton stands inside its body, not metres away),
+  - each duplicated mesh's world bbox matches its source mesh's world bbox at rest
+    (deformation is identity at rest -- the body looks like the source),
+  - placement_mode in the report is "source" (distributed) or "grid" (co-located), and
+    distributed characters keep distinct world locations.
+
+Outputs go to a fresh tempdir via OPEN_JAYWALKER_OUTPUT_ROOT so committed fixtures are
+untouched. RESULTS of a live run should be recorded by the operator below this header.
+
+--- LIVE RUN RESULTS (fill in after running) ---
+  Date:
+  Asset:
+  Overall:
+------------------------------------------------
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.append(_HERE)
+
+import bpy  # noqa: E402
+
+from _harness import ensure_src_on_path, reload_pipeline_modules  # noqa: E402
+
+
+# Generated rig height must be within this ratio of the paired body height (canonical
+# metres). A value near 1.0 means rig and body share one frame; the pre-fix bug gave ~39.
+_HEIGHT_RATIO_TOLERANCE = 0.25  # accept 0.75x .. 1.25x
+# Rig bbox-center may sit at most this multiple of the body's largest horizontal extent
+# away from the body bbox-center (skeleton inside the body).
+_INSIDE_BODY_FOOTPRINT_MULTIPLE = 1.0
+# Mesh rest-pose bbox match tolerance, in metres.
+_REST_BBOX_TOLERANCE_M = 1e-3
+
+
+def _run_inspector_and_classifier(output_root: str) -> Path:
+    os.environ["OPEN_JAYWALKER_OUTPUT_ROOT"] = output_root
+    print("Runbook output dir: {0}".format(output_root))
+
+    from blender_builder import purge_previous_generated_artifacts
+    purged = purge_previous_generated_artifacts(bpy)
+    if purged:
+        print("Purged {0} leftover generated artifact(s) from a previous run.".format(purged))
+
+    from inspector import inspect_scene
+    from classifier import write_asset_report
+
+    inspect_result = inspect_scene()
+    if not inspect_result:
+        raise RuntimeError(
+            "Inspector did not export anything. Make sure a crowd .blend with an armature is open."
+        )
+    output_dir = Path(inspect_result["output_dir"]).resolve()
+    if inspect_result.get("diagnostics_ran") or not inspect_result.get("exported_files"):
+        raise RuntimeError(
+            "Inspector wrote diagnostics rather than exports. Asset is unsupported: {0}".format(output_dir)
+        )
+    write_asset_report(output_dir)
+    return output_dir
+
+
+def _world_bbox(obj):
+    """Axis-aligned world bbox (min, max) of a mesh/armature object's bound_box."""
+    from mathutils import Vector
+    corners = [obj.matrix_world @ Vector(c) for c in obj.bound_box]
+    mins = [min(c[i] for c in corners) for i in range(3)]
+    maxs = [max(c[i] for c in corners) for i in range(3)]
+    return mins, maxs
+
+
+def _height(mins, maxs):
+    return maxs[2] - mins[2]  # Z is up in canonical metres
+
+
+def _center(mins, maxs):
+    return [(mins[i] + maxs[i]) / 2.0 for i in range(3)]
+
+
+def _horizontal_extent(mins, maxs):
+    return max(maxs[0] - mins[0], maxs[1] - mins[1])
+
+
+def _check_character(child_collection, asset_name, character_id, report_by_id, failures):
+    armature_obj = next(
+        (o for o in child_collection.all_objects if getattr(o, "type", None) == "ARMATURE"), None
+    )
+    meshes = [o for o in child_collection.all_objects if getattr(o, "type", None) == "MESH"]
+    if armature_obj is None:
+        failures.append("{0}: no armature".format(character_id))
+        return
+    if not meshes:
+        failures.append("{0}: no body mesh".format(character_id))
+        return
+
+    arm_min, arm_max = _world_bbox(armature_obj)
+    body_min = [min(_world_bbox(m)[0][i] for m in meshes) for i in range(3)]
+    body_max = [max(_world_bbox(m)[1][i] for m in meshes) for i in range(3)]
+
+    rig_h = _height(arm_min, arm_max)
+    body_h = _height(body_min, body_max)
+
+    # 1. Height parity (canonical metres; no ~39x).
+    if body_h > 1e-4:
+        ratio = rig_h / body_h
+        if abs(ratio - 1.0) > _HEIGHT_RATIO_TOLERANCE:
+            failures.append(
+                "{0}: rig/body height ratio {1:.2f} out of tolerance (rig={2:.3f}m body={3:.3f}m)".format(
+                    character_id, ratio, rig_h, body_h
+                )
+            )
+
+    # 2. Skeleton inside body (centers close in the ground plane).
+    arm_c = _center(arm_min, arm_max)
+    body_c = _center(body_min, body_max)
+    horiz = max(_horizontal_extent(body_min, body_max), 1e-3)
+    planar_gap = max(abs(arm_c[0] - body_c[0]), abs(arm_c[1] - body_c[1]))
+    if planar_gap > _INSIDE_BODY_FOOTPRINT_MULTIPLE * horiz:
+        failures.append(
+            "{0}: rig sits {1:.3f}m from body center (> {2:.3f}m body width); not inside body".format(
+                character_id, planar_gap, horiz
+            )
+        )
+
+    # 3. Grp_Root at the recorded placement location.
+    grp = next(
+        (o for o in child_collection.all_objects
+         if getattr(o, "type", None) == "EMPTY" and o.name.startswith("Grp_Root")),
+        None,
+    )
+    char_report = report_by_id.get(character_id, {})
+    recorded = char_report.get("grp_root_location")
+    if grp is not None and recorded is not None:
+        gap = max(abs(grp.location[i] - recorded[i]) for i in range(3))
+        if gap > 1e-3:
+            failures.append(
+                "{0}: Grp_Root at {1} != recorded grp_root_location {2}".format(
+                    character_id, list(grp.location), recorded
+                )
+            )
+
+    print(
+        "  {0}: rig_h={1:.3f}m body_h={2:.3f}m planar_gap={3:.3f}m mode={4}".format(
+            character_id, rig_h, body_h, planar_gap, char_report.get("placement_mode")
+        )
+    )
+
+
+def main() -> None:
+    print("=" * 60)
+    print("CROWD CANONICAL-FRAME + PLACEMENT RUNBOOK (Issue #49)")
+    print("=" * 60)
+
+    ensure_src_on_path()
+    reload_pipeline_modules()
+
+    output_root = tempfile.mkdtemp(prefix="open_jaywalker_canonical_runbook_")
+    asset_dir = _run_inspector_and_classifier(output_root)
+
+    from builder import build_character_specs_from_asset_dir, GENERATED_MARKER_KEY
+    from build_runner import run_build
+
+    resolved = build_character_specs_from_asset_dir(asset_dir)
+    if not resolved["crowd"]:
+        raise RuntimeError(
+            "Open asset is single-character; this runbook needs a crowd .blend."
+        )
+    asset_name = resolved["asset_name"]
+
+    # Build in place (no export) so we can measure the in-scene result.
+    report = run_build(asset_dir, bpy, packaging_mode="inplace_only")
+
+    report_by_id = {c["character_id"]: c for c in report.get("characters", [])}
+
+    failures = []
+    wrapper = bpy.data.collections.get(resolved["wrapper_collection_name"])
+    if wrapper is None or not bool(wrapper.get(GENERATED_MARKER_KEY)):
+        failures.append("wrapper collection missing or not generated")
+    else:
+        world_locations = []
+        modes = set()
+        for child in wrapper.children:
+            character_id = child.name.replace("ASAM_{0}_".format(asset_name), "")
+            _check_character(child, asset_name, character_id, report_by_id, failures)
+            cr = report_by_id.get(character_id, {})
+            if cr.get("grp_root_location") is not None:
+                world_locations.append(tuple(round(v, 4) for v in cr["grp_root_location"]))
+            if cr.get("placement_mode"):
+                modes.add(cr["placement_mode"])
+
+        # 4. Distributed crowds must keep distinct world locations.
+        if "source" in modes and len(world_locations) != len(set(world_locations)):
+            failures.append("placement_mode 'source' but duplicate Grp_Root locations (bodies collapsed)")
+        print("Placement modes observed: {0}".format(sorted(modes)))
+
+    print("-" * 60)
+    print("Characters built: {0}".format(len(report.get("characters", []))))
+    print("Characters failed: {0}".format(len(report.get("failed_characters", []))))
+    if failures:
+        print("Overall: FAIL")
+        for failure in failures:
+            print("  - {0}".format(failure))
+    else:
+        print("Overall: PASS")
+
+
+if __name__ == "__main__":
+    main()
+else:
+    main()

--- a/tests/fixtures/LowPolyCharacter4/builder_report.json
+++ b/tests/fixtures/LowPolyCharacter4/builder_report.json
@@ -5,6 +5,13 @@
   "group_root_name": "Grp_Root",
   "generated_armature_name": "Armature_LowPolyCharacter4",
   "collection_action": "rebuild",
+  "placement_mode": "source",
+  "grp_root_location": [
+    5.960464477539063e-08,
+    0.05099785327911377,
+    0.0033478213008493185
+  ],
+  "applied_grid_offset": null,
   "duplicated_meshes": [
     {
       "source_mesh_name": "Cube",

--- a/tests/fixtures/openmatexamplehuman/builder_report.json
+++ b/tests/fixtures/openmatexamplehuman/builder_report.json
@@ -5,6 +5,13 @@
   "group_root_name": "Grp_Root_openmatexamplehuman",
   "generated_armature_name": "Armature_openmatexamplehuman",
   "collection_action": "create",
+  "placement_mode": "source",
+  "grp_root_location": [
+    0.08631828427314758,
+    0.009727418422698975,
+    -0.003222084604203701
+  ],
+  "applied_grid_offset": null,
   "duplicated_meshes": [
     {
       "source_mesh_name": "Accessories_Wristband",

--- a/tests/test_armature_inspector_metadata.py
+++ b/tests/test_armature_inspector_metadata.py
@@ -193,5 +193,59 @@ class ArmatureInspectorMetadataTests(unittest.TestCase):
         self.assertAlmostEqual(result[0]["tail"][2], 40.0 * 0.0254)
 
 
+    def test_collect_armature_mesh_bounds_returns_world_points(self):
+        # FakeVector is a tuple subclass so indexing ([0],[1],[2]) and type(vec)((...))
+        # both work — satisfying FakeMatrix.__matmul__.
+        class FakeVector(tuple):
+            pass
+
+        class FakeMatrix:
+            def __init__(self, s):
+                self.s = s
+
+            def __matmul__(self, vec):
+                return type(vec)((self.s * vec[0], self.s * vec[1], self.s * vec[2]))
+
+            def inverted(self):  # must NOT be called anymore
+                raise AssertionError(
+                    "armature inverse must not be used; bounds are world-space"
+                )
+
+        class V(tuple):
+            pass
+
+        class FakeMesh:
+            type = "MESH"
+            name = "Body"
+            parent = None
+            modifiers = []
+            matrix_world = FakeMatrix(0.0254)
+            bound_box = [V((0.0, 0.0, 0.0)), V((100.0, 0.0, 0.0))]
+
+        fake_mathutils = types.SimpleNamespace(Vector=FakeVector)
+        fake_bpy = types.SimpleNamespace(
+            data=types.SimpleNamespace(filepath="", objects=[], armatures=[]),
+        )
+        # mathutils is imported inside the function body at call time, so it must be
+        # present in sys.modules throughout module import AND the function call.
+        with mock.patch.dict(sys.modules, {"bpy": fake_bpy, "mathutils": fake_mathutils}):
+            if "inspector" in sys.modules:
+                del sys.modules["inspector"]
+            inspector = importlib.import_module("inspector")
+
+            arm = type("Arm", (), {"matrix_world": FakeMatrix(0.0254)})()
+            # Force the driven-mesh detection to return our fake mesh:
+            original = inspector._meshes_driven_by_armature
+            inspector._meshes_driven_by_armature = lambda a: [FakeMesh()]
+            try:
+                points, names = inspector._collect_armature_mesh_bounds(arm)
+            finally:
+                inspector._meshes_driven_by_armature = original
+
+        self.assertEqual(names, ["Body"])
+        # World-space: 100.0 * 0.0254 = 2.54 — NOT armature-local
+        self.assertAlmostEqual(points[1][0], 100.0 * 0.0254)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_armature_inspector_metadata.py
+++ b/tests/test_armature_inspector_metadata.py
@@ -155,5 +155,43 @@ class ArmatureInspectorMetadataTests(unittest.TestCase):
         )
 
 
+    def test_extract_armature_geometry_returns_world_coordinates(self):
+        fake_bpy = types.SimpleNamespace(
+            data=types.SimpleNamespace(filepath="", objects=[], armatures=[]),
+        )
+        with mock.patch.dict(sys.modules, {"bpy": fake_bpy}):
+            if "inspector" in sys.modules:
+                del sys.modules["inspector"]
+            inspector = importlib.import_module("inspector")
+
+        class FakeMatrix:
+            # 0.0254 uniform scale, no rotation/translation — mirrors 1000idles Object_4.
+            def __matmul__(self, vec):
+                return type(vec)((0.0254 * vec[0], 0.0254 * vec[1], 0.0254 * vec[2]))
+
+        class V(tuple):
+            pass
+
+        class FakeBone:
+            def __init__(self):
+                self.name = "Pelvis"
+                self.parent = None
+                self.head_local = V((0.0, 0.0, 35.0))
+                self.tail_local = V((0.0, 0.0, 40.0))
+                self.length = 5.0
+                self.matrix_local = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
+
+        class FakeData:
+            bones = [FakeBone()]
+
+        class FakeArmature:
+            data = FakeData()
+            matrix_world = FakeMatrix()
+
+        result = inspector.extract_armature_geometry(FakeArmature())
+        self.assertAlmostEqual(result[0]["head"][2], 35.0 * 0.0254)
+        self.assertAlmostEqual(result[0]["tail"][2], 40.0 * 0.0254)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_armature_inspector_metadata.py
+++ b/tests/test_armature_inspector_metadata.py
@@ -247,5 +247,76 @@ class ArmatureInspectorMetadataTests(unittest.TestCase):
         self.assertAlmostEqual(points[1][0], 100.0 * 0.0254)
 
 
+    def test_build_mesh_binding_includes_world_bbox_per_mesh(self):
+        class FakeVector(tuple):
+            pass
+
+        class FakeMatrix:
+            def __matmul__(self, vec):
+                # translate by (32, -10, 0) — multiply keeps coords then adds offset
+                return type(vec)((vec[0] + 32.0, vec[1] - 10.0, vec[2]))
+
+        class FakeVertexGroup:
+            def __init__(self, name, index):
+                self.name = name
+                self.index = index
+
+        class FakeMeshData:
+            vertices = []
+
+        class FakeMesh:
+            type = "MESH"
+            name = "Body"
+            parent = None  # no parent link; modifier link will be set below
+            modifiers = []
+            vertex_groups = [FakeVertexGroup("Pelvis", 0)]
+            data = FakeMeshData()
+            material_slots = []
+            matrix_world = FakeMatrix()
+            # Unit cube corners (8 corners)
+            bound_box = [
+                FakeVector((0.0, 0.0, 0.0)),
+                FakeVector((1.0, 0.0, 0.0)),
+                FakeVector((1.0, 1.0, 0.0)),
+                FakeVector((0.0, 1.0, 0.0)),
+                FakeVector((0.0, 0.0, 1.0)),
+                FakeVector((1.0, 0.0, 1.0)),
+                FakeVector((1.0, 1.0, 1.0)),
+                FakeVector((0.0, 1.0, 1.0)),
+            ]
+
+        fake_mathutils = types.SimpleNamespace(Vector=FakeVector)
+        fake_bpy = types.SimpleNamespace(
+            data=types.SimpleNamespace(filepath="", objects=[], armatures=[]),
+        )
+
+        with mock.patch.dict(sys.modules, {"bpy": fake_bpy, "mathutils": fake_mathutils}):
+            if "inspector" in sys.modules:
+                del sys.modules["inspector"]
+            inspector = importlib.import_module("inspector")
+
+            arm = types.SimpleNamespace(name="Rig")
+            original = inspector._meshes_driven_by_armature
+            inspector._meshes_driven_by_armature = lambda a: [FakeMesh()]
+            try:
+                binding = inspector.build_mesh_binding(arm)
+            finally:
+                inspector._meshes_driven_by_armature = original
+
+        self.assertEqual(len(binding["meshes"]), 1)
+        mesh = binding["meshes"][0]
+        self.assertIn("bbox", mesh)
+        self.assertEqual(sorted(mesh["bbox"].keys()), ["max", "min"])
+        self.assertEqual(len(mesh["bbox"]["min"]), 3)
+        self.assertEqual(len(mesh["bbox"]["max"]), 3)
+        # The translation adds (32,-10,0) so min=[32,-10,0] max=[33,-9,1]
+        self.assertAlmostEqual(mesh["bbox"]["min"][0], 32.0)
+        self.assertAlmostEqual(mesh["bbox"]["min"][1], -10.0)
+        self.assertAlmostEqual(mesh["bbox"]["min"][2], 0.0)
+        self.assertAlmostEqual(mesh["bbox"]["max"][0], 33.0)
+        self.assertAlmostEqual(mesh["bbox"]["max"][1], -9.0)
+        self.assertAlmostEqual(mesh["bbox"]["max"][2], 1.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -1393,6 +1393,41 @@ class AsamHumanBuilderTests(unittest.TestCase):
         self.assertEqual(spec["grp_root_world_location"], [32.0, -10.0, 0.0])
         self.assertEqual(spec["grp_root_local_origin"], [float(v) for v in plan["root_resolutions"][0]["grp_root_local_origin"]])
 
+    def test_builder_report_records_placement_fields(self):
+        asset_dir = _copy_asset_folder("openmatexamplehuman")
+        write_asset_report(asset_dir)
+        report, plan = load_builder_inputs(asset_dir)
+        source_bones = build_source_bone_index_from_export(asset_dir, plan["recommended_primary_armature"])
+        plan["root_resolutions"][0]["grp_root_world_location"] = [1.0, 2.0, 0.0]
+        plan["root_resolutions"][0]["placement_mode"] = "grid"
+        plan["root_resolutions"][0]["applied_grid_offset"] = [1.0, 2.0, 0.0]
+        spec = build_armature_spec(report, plan, source_bones)
+        bpy_module = _FakeBpy()
+        bpy_module.add_source_armature("Armature")
+        for mesh_record in plan["mesh_binding"]["meshes"]:
+            bpy_module.add_source_mesh(mesh_record["mesh_name"], bpy_module.data.objects.get("Armature"))
+        execution = build_armature_in_blender(spec, bpy_module)
+        builder_report = build_builder_report(spec, execution)
+        self.assertEqual(builder_report["placement_mode"], "grid")
+        self.assertEqual(builder_report["grp_root_location"], [1.0, 2.0, 0.0])
+        self.assertEqual(builder_report["applied_grid_offset"], [1.0, 2.0, 0.0])
+
+    def test_builder_report_placement_defaults_single_character(self):
+        asset_dir = _copy_asset_folder("openmatexamplehuman")
+        write_asset_report(asset_dir)
+        report, plan = load_builder_inputs(asset_dir)
+        source_bones = build_source_bone_index_from_export(asset_dir, plan["recommended_primary_armature"])
+        spec = build_armature_spec(report, plan, source_bones)
+        bpy_module = _FakeBpy()
+        bpy_module.add_source_armature("Armature")
+        for mesh_record in plan["mesh_binding"]["meshes"]:
+            bpy_module.add_source_mesh(mesh_record["mesh_name"], bpy_module.data.objects.get("Armature"))
+        execution = build_armature_in_blender(spec, bpy_module)
+        builder_report = build_builder_report(spec, execution)
+        self.assertEqual(builder_report["placement_mode"], "source")
+        self.assertEqual(builder_report["grp_root_location"], spec["grp_root_world_location"])
+        self.assertIsNone(builder_report["applied_grid_offset"])
+
 
 class CrowdNamingTests(unittest.TestCase):
     def test_apply_character_naming_overrides_generated_names(self):

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2406,6 +2406,45 @@ class CrowdSpecsFromAssetDirTests(unittest.TestCase):
         self.assertFalse(result["crowd"])
         self.assertEqual(len(result["specs"]), 1)
 
+    def test_crowd_character_specs_carry_placement_fields(self):
+        # Regression: per-character specs must carry grp_root_world_location and
+        # placement_mode end-to-end through the crowd fan-out.  The synthetic fixture
+        # has Hero000 at x=0 and Hero001 at x=5 m — spread >> 0.25 m threshold, so
+        # _assign_character_placements sets placement_mode="source" with distinct
+        # per-character anchors.  This test locks that the builder forwards those
+        # fields from each character's root_resolutions[0] onto the resolved spec.
+        from asam_human_builder.builder import build_character_specs_from_asset_dir
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            _write_crowd_asset(tmp)
+            resolved = build_character_specs_from_asset_dir(tmp)
+
+        self.assertTrue(resolved["crowd"])
+        self.assertEqual(len(resolved["character_specs"]), 2)
+
+        specs_by_id = {cid: spec for cid, spec in resolved["character_specs"]}
+
+        for cid, spec in resolved["character_specs"]:
+            self.assertIn(
+                spec["placement_mode"],
+                ("source", "grid"),
+                msg="character {0}: placement_mode missing or invalid".format(cid),
+            )
+            self.assertEqual(
+                len(spec["grp_root_world_location"]),
+                3,
+                msg="character {0}: grp_root_world_location must be length-3".format(cid),
+            )
+
+        # Characters are at distinct world x positions (0 vs 5), so their anchors differ.
+        loc_hero000 = specs_by_id["Hero000"]["grp_root_world_location"]
+        loc_hero001 = specs_by_id["Hero001"]["grp_root_world_location"]
+        self.assertNotEqual(
+            loc_hero000,
+            loc_hero001,
+            msg="Hero000 and Hero001 have distinct positions and must get distinct world locations",
+        )
+
 
 class SingleCharacterRegressionTests(unittest.TestCase):
     maxDiff = None

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -18,8 +18,10 @@ from asam_human_builder.builder import (  # noqa: E402
     build_armature_spec,
     build_armature_spec_from_asset_dir,
     build_builder_report,
+    build_source_bone_index_from_export,
     choose_generated_collection_action,
     compute_vertex_group_remap_plan,
+    load_builder_inputs,
     resolve_default_asset_dir,
     validate_builder_inputs,
 )
@@ -1371,6 +1373,25 @@ class AsamHumanBuilderTests(unittest.TestCase):
                 "ASAM_TestAsset",
                 "TestAsset",
             )
+
+    def test_spec_grp_root_world_location_defaults_to_local_origin(self):
+        # Single-character path: absent -> equals grp_root_local_origin (no behavior change).
+        asset_dir = _copy_asset_folder("openmatexamplehuman")
+        write_asset_report(asset_dir)
+        report, plan = load_builder_inputs(asset_dir)
+        source_bones = build_source_bone_index_from_export(asset_dir, plan["recommended_primary_armature"])
+        spec = build_armature_spec(report, plan, source_bones)
+        self.assertEqual(spec["grp_root_world_location"], spec["grp_root_local_origin"])
+
+    def test_spec_grp_root_world_location_uses_explicit_value(self):
+        asset_dir = _copy_asset_folder("openmatexamplehuman")
+        write_asset_report(asset_dir)
+        report, plan = load_builder_inputs(asset_dir)
+        source_bones = build_source_bone_index_from_export(asset_dir, plan["recommended_primary_armature"])
+        plan["root_resolutions"][0]["grp_root_world_location"] = [32.0, -10.0, 0.0]
+        spec = build_armature_spec(report, plan, source_bones)
+        self.assertEqual(spec["grp_root_world_location"], [32.0, -10.0, 0.0])
+        self.assertEqual(spec["grp_root_local_origin"], [float(v) for v in plan["root_resolutions"][0]["grp_root_local_origin"]])
 
 
 class CrowdNamingTests(unittest.TestCase):

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -27,6 +27,7 @@ from asam_human_builder.builder import (  # noqa: E402
 )
 from asam_human_builder.blender_builder import (  # noqa: E402
     build_armature_in_blender,
+    export_generated_blend,
     purge_previous_generated_artifacts,
 )
 from phase3_classifier.classifier import (  # noqa: E402
@@ -514,6 +515,14 @@ class _FakeOps:
         self.object = _FakeObjectOps(context)
 
 
+class _FakeLibraries:
+    def __init__(self):
+        self.write_calls = []
+
+    def write(self, filepath, datablocks, **kwargs):
+        self.write_calls.append({"filepath": filepath, "datablocks": datablocks, "kwargs": kwargs})
+
+
 class _FakeBpy:
     def __init__(self):
         self.context = _FakeContext()
@@ -522,6 +531,7 @@ class _FakeBpy:
         self.data.armatures = _FakeArmatureStore()
         self.data.meshes = _FakeMeshStore()
         self.data.collections = _FakeCollectionStore(self)
+        self.data.libraries = _FakeLibraries()
         self.data.scenes = [self.context.scene]
         # Expose isinstance-able type markers for purge_previous_generated_artifacts
         # to distinguish armature vs mesh data blocks without a parallel type-name
@@ -2531,6 +2541,31 @@ class SuccessMessageTests(unittest.TestCase):
         self.assertIn("Crowd built", msg)
         self.assertIn("2 characters", msg)
         self.assertIn("1 failed", msg)
+
+
+class ExportGeneratedBlendTests(unittest.TestCase):
+    def test_export_generated_blend_writes_wrapper_datablocks(self):
+        import tempfile
+        import os
+        fake_bpy = _FakeBpy()
+        wrapper = fake_bpy.data.collections.new("ASAM_demo")
+        wrapper[GENERATED_MARKER_KEY] = True
+        out = os.path.join(tempfile.mkdtemp(), "demo_asam.blend")
+        path = export_generated_blend(fake_bpy, "ASAM_demo", out)
+        self.assertEqual(path, out)
+        written = fake_bpy.data.libraries.write_calls[0]
+        self.assertIn(wrapper, list(written["datablocks"]))
+
+    def test_export_generated_blend_refuses_non_generated_collection(self):
+        fake_bpy = _FakeBpy()
+        fake_bpy.data.collections.new("NotGenerated")  # no generated marker
+        with self.assertRaises(ValueError):
+            export_generated_blend(fake_bpy, "NotGenerated", "/tmp/x.blend")
+
+    def test_export_generated_blend_refuses_missing_collection(self):
+        fake_bpy = _FakeBpy()
+        with self.assertRaises(ValueError):
+            export_generated_blend(fake_bpy, "DoesNotExist", "/tmp/x.blend")
 
 
 if __name__ == "__main__":

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2093,6 +2093,15 @@ class CrowdBlenderTests(unittest.TestCase):
             )
         self.assertIsNotNone(fake.data.objects.get("UserMesh"))
 
+    def test_grp_root_placed_at_world_location_not_local_origin(self):
+        fake_bpy = _fake_with_source_armature("Object_4")
+        spec = _minimal_crowd_build_spec(source_armature="Object_4")
+        spec["grp_root_local_origin"] = [0.0, 0.0, 0.0]       # bone-bbox (rig base)
+        spec["grp_root_world_location"] = [32.0, -10.0, 0.0]  # body anchor
+        build_armature_in_blender(spec, fake_bpy)
+        grp = fake_bpy.data.objects.get(spec["group_root_name"])
+        self.assertEqual(list(grp.location), [32.0, -10.0, 0.0])
+
 
 class CrowdDetectionTests(unittest.TestCase):
     def test_is_crowd_plan_true_when_characters_present(self):

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2570,5 +2570,30 @@ class ExportGeneratedBlendTests(unittest.TestCase):
             export_generated_blend(fake_bpy, "DoesNotExist", "/tmp/x.blend")
 
 
+class PlacementDeltaTests(unittest.TestCase):
+    """The body must travel with its rig: mesh delta == rig relocation delta."""
+
+    def test_placement_delta_is_world_minus_local(self):
+        from asam_human_builder import blender_builder
+        spec = {"grp_root_world_location": [32.0, -10.0, 0.0], "grp_root_local_origin": [0.0, 0.0, 0.0]}
+        self.assertEqual(blender_builder._placement_delta(spec), [32.0, -10.0, 0.0])
+
+    def test_placement_delta_zero_for_single_character(self):
+        from asam_human_builder import blender_builder
+        # Single-character: the two anchors coincide -> no relocation -> mesh unchanged.
+        spec = {"grp_root_world_location": [0.5, 1.0, 0.0], "grp_root_local_origin": [0.5, 1.0, 0.0]}
+        self.assertEqual(blender_builder._placement_delta(spec), [0.0, 0.0, 0.0])
+
+    def test_placement_delta_defaults_when_world_absent(self):
+        from asam_human_builder import blender_builder
+        spec = {"grp_root_local_origin": [2.0, 3.0, 4.0]}
+        self.assertEqual(blender_builder._placement_delta(spec), [0.0, 0.0, 0.0])
+
+    def test_translated_matrix_zero_delta_returns_same_object(self):
+        from asam_human_builder import blender_builder
+        sentinel = object()  # a non-matrix; zero delta must not touch it
+        self.assertIs(blender_builder._translated_matrix(sentinel, [0.0, 0.0, 0.0]), sentinel)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2555,6 +2555,8 @@ class ExportGeneratedBlendTests(unittest.TestCase):
         self.assertEqual(path, out)
         written = fake_bpy.data.libraries.write_calls[0]
         self.assertIn(wrapper, list(written["datablocks"]))
+        # fake_user=True keeps the exported collection from being dropped as orphan data.
+        self.assertTrue(written["kwargs"].get("fake_user"))
 
     def test_export_generated_blend_refuses_non_generated_collection(self):
         fake_bpy = _FakeBpy()

--- a/tests/test_build_runner.py
+++ b/tests/test_build_runner.py
@@ -60,16 +60,22 @@ class RunBuildPackagingTests(unittest.TestCase):
             p.start(); self.addCleanup(p.stop)
         with mock.patch.object(build_runner, "export_generated_blend", return_value="/x/A_asam.blend") as export, \
              mock.patch.object(build_runner, "purge_previous_generated_artifacts") as purge:
-            build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_export")
+            report = build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_export")
             export.assert_called_once()
             purge.assert_not_called()
+            self.assertEqual(report["packaging_mode"], "inplace_export")
+            self.assertEqual(report["exported_blend_path"], "/x/A_asam.blend")
+            self.assertIsNone(report["export_error"])
 
     def test_inplace_only_skips_export(self):
         for p in self._patch_single():
             p.start(); self.addCleanup(p.stop)
         with mock.patch.object(build_runner, "export_generated_blend") as export:
-            build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
+            report = build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
             export.assert_not_called()
+            # packaging_mode is recorded even when no export happens (consistent report shape).
+            self.assertEqual(report["packaging_mode"], "inplace_only")
+            self.assertIsNone(report["exported_blend_path"])
 
     def test_separate_only_exports_then_purges(self):
         for p in self._patch_single():

--- a/tests/test_build_runner.py
+++ b/tests/test_build_runner.py
@@ -22,7 +22,17 @@ class RunBuildTests(unittest.TestCase):
             report = build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
 
         build_one.assert_called_once_with(spec, "BPY")
-        self.assertEqual(report, {"asset_name": "A"})
+        # inplace_only performs no export but still records the packaging mode for a
+        # consistent report shape across modes.
+        self.assertEqual(
+            report,
+            {
+                "asset_name": "A",
+                "packaging_mode": "inplace_only",
+                "exported_blend_path": None,
+                "export_error": None,
+            },
+        )
 
     def test_crowd_dispatch(self):
         resolved = {

--- a/tests/test_build_runner.py
+++ b/tests/test_build_runner.py
@@ -13,14 +13,15 @@ from asam_human_builder import build_runner  # noqa: E402
 
 class RunBuildTests(unittest.TestCase):
     def test_single_character_dispatch(self):
-        resolved = {"crowd": False, "asset_name": "A", "specs": ["SPEC"]}
+        spec = {"generated_collection_name": "ASAM_A", "name": "SPEC"}
+        resolved = {"crowd": False, "asset_name": "A", "specs": [spec]}
         with mock.patch.object(build_runner, "build_character_specs_from_asset_dir", return_value=resolved), \
              mock.patch.object(build_runner, "build_armature_in_blender", return_value={"exec": True}) as build_one, \
              mock.patch.object(build_runner, "write_builder_report", return_value=({"asset_name": "A"}, Path("/x/builder_report.json"))), \
              mock.patch.object(build_runner, "print_builder_summary"):
-            report = build_runner.run_build(Path("/x"), bpy="BPY")
+            report = build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
 
-        build_one.assert_called_once_with("SPEC", "BPY")
+        build_one.assert_called_once_with(spec, "BPY")
         self.assertEqual(report, {"asset_name": "A"})
 
     def test_crowd_dispatch(self):
@@ -36,10 +37,55 @@ class RunBuildTests(unittest.TestCase):
              mock.patch.object(build_runner, "build_crowd_in_blender", return_value={"exec": True}) as build_crowd, \
              mock.patch.object(build_runner, "build_crowd_builder_report", return_value=crowd_report), \
              mock.patch.object(build_runner, "write_crowd_builder_report", return_value=(crowd_report, Path("/x/builder_report.json"))):
-            report = build_runner.run_build(Path("/x"), bpy="BPY")
+            report = build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
 
         build_crowd.assert_called_once_with("Crowd", "Crowd_Humans", [("c0", "SPEC0")], {"source_armature": "Root"}, "BPY")
         self.assertEqual(report, crowd_report)
+
+
+class RunBuildPackagingTests(unittest.TestCase):
+    def _patch_single(self):
+        return [
+            mock.patch.object(build_runner, "build_character_specs_from_asset_dir",
+                              return_value={"crowd": False, "asset_name": "A",
+                                            "specs": [{"generated_collection_name": "ASAM_A"}]}),
+            mock.patch.object(build_runner, "build_armature_in_blender", return_value={"exec": True}),
+            mock.patch.object(build_runner, "write_builder_report",
+                              return_value=({"asset_name": "A"}, Path("/x/builder_report.json"))),
+            mock.patch.object(build_runner, "print_builder_summary"),
+        ]
+
+    def test_inplace_export_calls_export(self):
+        for p in self._patch_single():
+            p.start(); self.addCleanup(p.stop)
+        with mock.patch.object(build_runner, "export_generated_blend", return_value="/x/A_asam.blend") as export, \
+             mock.patch.object(build_runner, "purge_previous_generated_artifacts") as purge:
+            build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_export")
+            export.assert_called_once()
+            purge.assert_not_called()
+
+    def test_inplace_only_skips_export(self):
+        for p in self._patch_single():
+            p.start(); self.addCleanup(p.stop)
+        with mock.patch.object(build_runner, "export_generated_blend") as export:
+            build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
+            export.assert_not_called()
+
+    def test_separate_only_exports_then_purges(self):
+        for p in self._patch_single():
+            p.start(); self.addCleanup(p.stop)
+        with mock.patch.object(build_runner, "export_generated_blend", return_value="/x/A_asam.blend"), \
+             mock.patch.object(build_runner, "purge_previous_generated_artifacts") as purge:
+            build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="separate_only")
+            purge.assert_called_once()
+
+    def test_export_failure_does_not_abort(self):
+        for p in self._patch_single():
+            p.start(); self.addCleanup(p.stop)
+        with mock.patch.object(build_runner, "export_generated_blend", side_effect=RuntimeError("disk full")):
+            report = build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_export")
+            self.assertEqual(report.get("exported_blend_path"), None)
+            self.assertIn("export_error", report)
 
 
 if __name__ == "__main__":

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -303,5 +303,111 @@ class BodyAnchorFromMeshesTests(unittest.TestCase):
         self.assertIsNone(segmentation.body_anchor_from_meshes([{"mesh_name": "x"}], up_axis_index=2, up_sign=1))
 
 
+class CharacterPlacementTests(unittest.TestCase):
+    def _crowd_primary_data_distributed(self):
+        """Two characters with bones at different XY positions (Hero001 offset by 3 m on Y)."""
+        bones = []
+        offsets = {"Hero000": [0.0, 0.0], "Hero001": [0.0, 3.0]}
+        for prefix, (ox, oy) in offsets.items():
+            bones += [
+                {"name": f"{prefix}COM_0", "parent": "_rootJoint",
+                 "head": [ox, oy, 0.0], "tail": [ox, oy, 0.1], "length": 0.1},
+                {"name": f"{prefix}Pelvis_1", "parent": f"{prefix}COM_0",
+                 "head": [ox, oy, 1.0], "tail": [ox, oy, 1.1], "length": 0.1},
+                {"name": f"{prefix}Spine0_2", "parent": f"{prefix}Pelvis_1",
+                 "head": [ox, oy, 1.1], "tail": [ox, oy, 1.3], "length": 0.2},
+                {"name": f"{prefix}Spine1_3", "parent": f"{prefix}Spine0_2",
+                 "head": [ox, oy, 1.3], "tail": [ox, oy, 1.5], "length": 0.2},
+                {"name": f"{prefix}Head_4", "parent": f"{prefix}Spine1_3",
+                 "head": [ox, oy, 1.5], "tail": [ox, oy, 1.7], "length": 0.2},
+                {"name": f"{prefix}LThigh_5", "parent": f"{prefix}Pelvis_1",
+                 "head": [ox + 0.1, oy, 1.0], "tail": [ox + 0.1, oy, 0.5], "length": 0.5},
+            ]
+        bones.insert(0, {"name": "_rootJoint", "parent": None,
+                         "head": [0, 0, 0], "tail": [0, 0, 0.1], "length": 0.1})
+        return {
+            "armature_name": "Object_4",
+            "source_file": "crowd.blend",
+            "filter": None,
+            "bone_count": len(bones),
+            "bones": bones,
+            "chains": {
+                "spine": [
+                    [f"Hero000Spine0_2", f"Hero000Spine1_3"],
+                    [f"Hero001Spine0_2", f"Hero001Spine1_3"],
+                ],
+                "leg": {"left": [], "right": [], "unsided": []},
+                "arm": {"left": [], "right": [], "unsided": []},
+            },
+        }
+
+    def _crowd_mesh_binding_distributed(self):
+        """Mesh binding where each character has a bbox at its respective position."""
+        return {
+            "armature_object_name": "Object_4",
+            "meshes": [
+                {
+                    "mesh_name": "Hero000_Body",
+                    "armature_link": "modifier",
+                    "modifiers": [],
+                    "vertex_groups": ["Hero000Pelvis_1", "Hero000LThigh_5"],
+                    "vertex_group_stats": {
+                        "non_empty_group_count": 2,
+                        "per_group": [
+                            {"name": "Hero000Pelvis_1", "weighted_vertex_count": 5},
+                            {"name": "Hero000LThigh_5", "weighted_vertex_count": 3},
+                        ],
+                    },
+                    "material_slots": [],
+                    "warnings": [],
+                    # Hero000 body is centred around (0, 0)
+                    "bbox": {"min": [-0.5, -0.5, 0.0], "max": [0.5, 0.5, 1.8]},
+                },
+                {
+                    "mesh_name": "Hero001_Body",
+                    "armature_link": "modifier",
+                    "modifiers": [],
+                    "vertex_groups": ["Hero001Pelvis_1", "Hero001LThigh_5"],
+                    "vertex_group_stats": {
+                        "non_empty_group_count": 2,
+                        "per_group": [
+                            {"name": "Hero001Pelvis_1", "weighted_vertex_count": 5},
+                            {"name": "Hero001LThigh_5", "weighted_vertex_count": 3},
+                        ],
+                    },
+                    "material_slots": [],
+                    "warnings": [],
+                    # Hero001 body is centred around (0, 3)
+                    "bbox": {"min": [-0.5, 2.5, 0.0], "max": [0.5, 3.5, 1.8]},
+                },
+            ],
+        }
+
+    def _segment_two_character_crowd_distributed(self):
+        from phase3_classifier import segmentation
+        primary = self._crowd_primary_data_distributed()
+        primary["mesh_binding"] = self._crowd_mesh_binding_distributed()
+        inp = ArmatureInput(
+            armature_name="Object_4",
+            all_path=Path("Object_4_all.json"),
+            filtered_path=None,
+            primary_path=Path("Object_4_all.json"),
+            support_path=None,
+            primary_data=primary,
+            support_data=None,
+        )
+        return segmentation.segment_recommended("crowd", inp)
+
+    def test_distributed_characters_preserve_source_positions(self):
+        from phase3_classifier import segmentation
+        result = self._segment_two_character_crowd_distributed()
+        by_id = {c["character_id"]: c for c in result.plan_characters}
+        rr0 = by_id["Hero000"]["root_resolutions"][0]
+        rr1 = by_id["Hero001"]["root_resolutions"][0]
+        self.assertEqual(rr0["placement_mode"], "source")
+        self.assertEqual(rr1["placement_mode"], "source")
+        self.assertNotEqual(rr0["grp_root_world_location"], rr1["grp_root_world_location"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -408,6 +408,82 @@ class CharacterPlacementTests(unittest.TestCase):
         self.assertEqual(rr1["placement_mode"], "source")
         self.assertNotEqual(rr0["grp_root_world_location"], rr1["grp_root_world_location"])
 
+    # ------------------------------------------------------------------
+    # Co-located variant — both mesh bboxes share the same planar centre
+    # so planar spread <= COLOCATED_SPREAD_THRESHOLD and _apply_grid fires.
+    # ------------------------------------------------------------------
+
+    def _crowd_mesh_binding_colocated(self):
+        """Mesh binding where BOTH characters' body bbox is centred at (0, 0)."""
+        return {
+            "armature_object_name": "Object_4",
+            "meshes": [
+                {
+                    "mesh_name": "Hero000_Body",
+                    "armature_link": "modifier",
+                    "modifiers": [],
+                    "vertex_groups": ["Hero000Pelvis_1", "Hero000LThigh_5"],
+                    "vertex_group_stats": {
+                        "non_empty_group_count": 2,
+                        "per_group": [
+                            {"name": "Hero000Pelvis_1", "weighted_vertex_count": 5},
+                            {"name": "Hero000LThigh_5", "weighted_vertex_count": 3},
+                        ],
+                    },
+                    "material_slots": [],
+                    "warnings": [],
+                    # centred at (0, 0) — same planar position as Hero001
+                    "bbox": {"min": [-0.5, -0.5, 0.0], "max": [0.5, 0.5, 1.8]},
+                },
+                {
+                    "mesh_name": "Hero001_Body",
+                    "armature_link": "modifier",
+                    "modifiers": [],
+                    "vertex_groups": ["Hero001Pelvis_1", "Hero001LThigh_5"],
+                    "vertex_group_stats": {
+                        "non_empty_group_count": 2,
+                        "per_group": [
+                            {"name": "Hero001Pelvis_1", "weighted_vertex_count": 5},
+                            {"name": "Hero001LThigh_5", "weighted_vertex_count": 3},
+                        ],
+                    },
+                    "material_slots": [],
+                    "warnings": [],
+                    # also centred at (0, 0) — co-located with Hero000
+                    "bbox": {"min": [-0.5, -0.5, 0.0], "max": [0.5, 0.5, 1.8]},
+                },
+            ],
+        }
+
+    def _segment_two_character_crowd_colocated(self):
+        from phase3_classifier import segmentation
+        # Reuse the distributed bone data — placement is driven by mesh bboxes,
+        # not bone positions, so bone offsets do not affect placement_mode.
+        primary = self._crowd_primary_data_distributed()
+        primary["mesh_binding"] = self._crowd_mesh_binding_colocated()
+        inp = ArmatureInput(
+            armature_name="Object_4",
+            all_path=Path("Object_4_all.json"),
+            filtered_path=None,
+            primary_path=Path("Object_4_all.json"),
+            support_path=None,
+            primary_data=primary,
+            support_data=None,
+        )
+        return segmentation.segment_recommended("crowd", inp)
+
+    def test_colocated_characters_are_gridded(self):
+        from phase3_classifier import segmentation
+        result = self._segment_two_character_crowd_colocated()
+        by_id = {c["character_id"]: c for c in result.plan_characters}
+        rr0 = by_id["Hero000"]["root_resolutions"][0]
+        rr1 = by_id["Hero001"]["root_resolutions"][0]
+        self.assertEqual(rr0["placement_mode"], "grid")
+        self.assertEqual(rr1["placement_mode"], "grid")
+        self.assertNotEqual(rr0["grp_root_world_location"], rr1["grp_root_world_location"])
+        self.assertIn("applied_grid_offset", rr0)
+        self.assertIn("applied_grid_offset", rr1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -270,5 +270,38 @@ class SegmentRecommendedTests(unittest.TestCase):
         self.assertEqual(result.decomposition["unassigned_meshes"], ["Prop"])
 
 
+class BodyAnchorFromMeshesTests(unittest.TestCase):
+    def test_character_body_anchor_from_owned_mesh_bbox(self):
+        from phase3_classifier import segmentation
+        meshes = [
+            {"mesh_name": "Body", "bbox": {"min": [31.0, -11.0, 0.0], "max": [33.0, -9.0, 1.8]}},
+        ]
+        anchor = segmentation.body_anchor_from_meshes(meshes, up_axis_index=2, up_sign=1)
+        self.assertAlmostEqual(anchor[0], 32.0)   # planar center
+        self.assertAlmostEqual(anchor[1], -10.0)  # planar center
+        self.assertAlmostEqual(anchor[2], 0.0)    # ground = min on up axis (up_sign>=0)
+
+    def test_body_anchor_uses_max_on_up_axis_when_up_sign_negative(self):
+        from phase3_classifier import segmentation
+        meshes = [{"mesh_name": "B", "bbox": {"min": [0.0, 0.0, 0.0], "max": [2.0, 2.0, 2.0]}}]
+        anchor = segmentation.body_anchor_from_meshes(meshes, up_axis_index=2, up_sign=-1)
+        self.assertAlmostEqual(anchor[2], 2.0)    # ground = max when up_sign<0
+
+    def test_body_anchor_unions_multiple_meshes(self):
+        from phase3_classifier import segmentation
+        meshes = [
+            {"mesh_name": "A", "bbox": {"min": [0.0, 0.0, 0.0], "max": [1.0, 1.0, 1.0]}},
+            {"mesh_name": "B", "bbox": {"min": [3.0, 3.0, 0.0], "max": [4.0, 4.0, 2.0]}},
+        ]
+        anchor = segmentation.body_anchor_from_meshes(meshes, up_axis_index=2, up_sign=1)
+        self.assertAlmostEqual(anchor[0], 2.0)    # (min0=0, max4=4) -> center 2.0
+        self.assertAlmostEqual(anchor[1], 2.0)
+
+    def test_body_anchor_none_when_no_bboxes(self):
+        from phase3_classifier import segmentation
+        self.assertIsNone(segmentation.body_anchor_from_meshes([], up_axis_index=2, up_sign=1))
+        self.assertIsNone(segmentation.body_anchor_from_meshes([{"mesh_name": "x"}], up_axis_index=2, up_sign=1))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/setup_dev_link.ps1
+++ b/tools/setup_dev_link.ps1
@@ -1,0 +1,65 @@
+param (
+    [string]$BlenderVersion = ""
+)
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$addonDir = Join-Path $repoRoot "addon"
+
+if (-not (Test-Path $addonDir)) {
+    Write-Host "Error: Could not find addon directory at $addonDir" -ForegroundColor Red
+    exit 1
+}
+
+$blenderAppData = Join-Path $env:APPDATA "Blender Foundation\Blender"
+
+if (-not (Test-Path $blenderAppData)) {
+    Write-Host "Blender AppData directory not found at $blenderAppData" -ForegroundColor Yellow
+    Write-Host "You may need to run Blender at least once, or specify a custom path."
+    exit 1
+}
+
+$versionsToLink = @()
+
+if ($BlenderVersion -ne "") {
+    $versionsToLink += $BlenderVersion
+} else {
+    # Find all version directories (e.g. 3.0, 3.6, 4.0)
+    $dirs = Get-ChildItem -Path $blenderAppData -Directory | Where-Object { $_.Name -match "^\d+\.\d+$" }
+    foreach ($dir in $dirs) {
+        $versionsToLink += $dir.Name
+    }
+}
+
+if ($versionsToLink.Count -eq 0) {
+    Write-Host "No Blender versions found in $blenderAppData" -ForegroundColor Yellow
+    exit 1
+}
+
+foreach ($version in $versionsToLink) {
+    $targetAddonsDir = Join-Path $blenderAppData "$version\scripts\addons"
+    $targetLinkPath = Join-Path $targetAddonsDir "open_jaywalker"
+
+    if (-not (Test-Path $targetAddonsDir)) {
+        Write-Host "Creating $targetAddonsDir"
+        New-Item -ItemType Directory -Force -Path $targetAddonsDir | Out-Null
+    }
+
+    if (Test-Path $targetLinkPath) {
+        # Check if it's already a junction to the right place
+        $existingTarget = (Get-Item $targetLinkPath).Target
+        if ($existingTarget -eq $addonDir) {
+            Write-Host "Symlink already exists for Blender $version ($targetLinkPath -> $addonDir)" -ForegroundColor Green
+            continue
+        } else {
+            Write-Host "Removing existing open_jaywalker folder/link for Blender $version" -ForegroundColor Yellow
+            Remove-Item -Recurse -Force $targetLinkPath
+        }
+    }
+
+    Write-Host "Creating symlink for Blender $($version): $targetLinkPath -> $addonDir"
+    # Using Junction for Windows compatibility without needing admin rights
+    New-Item -ItemType Junction -Path $targetLinkPath -Value $addonDir | Out-Null
+    Write-Host "Successfully created symlink for Blender $version" -ForegroundColor Green
+}
+
+Write-Host "Done!"


### PR DESCRIPTION
## Summary

### #49 — Crowd build correctness (canonical frame + placement)
Running the pipeline on a crowd asset (`1000idles.blend`: 66 characters under one armature) produced rigs ~39x oversized, perpendicular, and stacked at the origin while bodies were tiny/scattered. Root cause: the builder dropped the source armature's object transform and anchored each character to its bone bbox instead of its body.

Fixes:
- **Inspector** exports bone geometry and per-mesh bbox in **world metres** (applies the armature world matrix); identity-transform single-character sources are unchanged.
- **Placement decoupled**: bones rebase about the bone bbox while `Grp_Root` is placed at the per-character body anchor (mesh bbox ground-center), so each rig lands at its real position; co-located crowds auto-grid.
- **Body follows rig**: each duplicated mesh is translated by the rig's relocation delta (`grp_root_world_location - grp_root_local_origin`) so the deformed body sits on its skeleton. Zero delta for single-character builds (byte-identical).
- Builder report records `placement_mode` / `grp_root_location` / `applied_grid_offset`.
- Selectable output packaging (in-place / in-place+export clean `.blend` / separate-file) surfaced in the add-on panel.

**Verified live on `1000idles.blend`:** all 66 bodies co-located with their rigs at the correct scattered positions, human-sized.

### #50 — Add-on auto-updater + dev-link workflow
- Vendored the CGCookie add-on updater; registered it and exposed update settings in the add-on preferences.
- `__init__` resolves symlinks and adds repo `src/` to `sys.path`, and `tools/setup_dev_link.ps1` junctions the installed add-on to the repo — so dev installs run repo code live (no rebuild/reinstall cycle). The updater's runtime-state dir is gitignored.

## Test plan
- `python -m unittest discover tests` → 284 passing.
- Single-character regression fixtures (`openmatexamplehuman`, `LowPolyCharacter4`) unchanged.
- Live build verified on `1000idles.blend`.

Closes #49.

Addresses #50 — updater integration is included; recommend verifying check/download/install in Blender before closing #50.