### PR TITLE
ASAM spine/orientation, weight consolidation, limb & extremity fixes

### DIFF
--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -94,7 +94,7 @@ def build_armature_in_blender(build_spec: dict, bpy_module=None, parent_collecti
         bpy_module, group_root_name, asset_name, collection, grp_root_location
     )
     armature_object = _create_armature_object(bpy_module, armature_name, asset_name, collection, group_root)
-    _populate_edit_bones(bpy_module, armature_object, build_spec["bones"])
+    _populate_edit_bones(bpy_module, armature_object, build_spec["bones"], build_spec.get("roll_align_axis"))
     # Force the dependency graph to evaluate the just-placed Grp_Root/armature so the
     # duplicated meshes below are positioned against their parent's CURRENT world
     # transform.
@@ -530,7 +530,18 @@ def _apply_vertex_group_renames(mesh_obj, renames: List[dict]) -> None:
             groups[index] = new_name
 
 
-def _populate_edit_bones(bpy_module, armature_object, bones: List[dict]) -> None:
+def _roll_axis_vector(axis):
+    """Return a value accepted by EditBone.align_roll. In Blender that is a
+    mathutils.Vector; outside Blender (tests) mathutils is unavailable, so the
+    raw sequence is returned and the fake records it directly."""
+    try:
+        from mathutils import Vector  # type: ignore
+    except ImportError:
+        return axis
+    return Vector(axis)
+
+
+def _populate_edit_bones(bpy_module, armature_object, bones: List[dict], roll_align_axis=None) -> None:
     _ensure_object_mode(bpy_module)
     _set_active_object(bpy_module, armature_object)
     bpy_module.ops.object.mode_set(mode="EDIT")
@@ -549,6 +560,11 @@ def _populate_edit_bones(bpy_module, armature_object, bones: List[dict]) -> None
         edit_bone = edit_bones[bone["name"]]
         edit_bone.parent = edit_bones[parent_name]
         edit_bone.use_connect = bool(bone.get("use_connect", False))
+
+    if roll_align_axis is not None:
+        axis_vector = _roll_axis_vector(roll_align_axis)
+        for bone in bones:
+            edit_bones[bone["name"]].align_roll(axis_vector)
 
     bpy_module.ops.object.mode_set(mode="OBJECT")
 

--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -393,6 +393,10 @@ def _duplicate_bound_meshes(
             group_names,
         )
         _apply_vertex_group_renames(generated_mesh, remap_plan["renames"])
+        _apply_weight_merges(generated_mesh, build_spec.get("weight_merges", []))
+        _purge_unbound_vertex_groups(
+            generated_mesh, {bone["name"] for bone in build_spec.get("bones", [])}
+        )
         if remap_plan["unmapped_groups"]:
             mesh_warnings.append("unmapped_vertex_groups:{0}".format(mesh_name))
         if remap_plan["asam_targets_without_source_group"]:
@@ -528,6 +532,65 @@ def _apply_vertex_group_renames(mesh_obj, renames: List[dict]) -> None:
         else:
             # The fake exposes vertex_groups as a list[str]; mutate in place.
             groups[index] = new_name
+
+
+def _apply_weight_merges(mesh_obj, merges: List[dict]) -> None:
+    """Merge orphaned source vertex groups into their target ASAM group (#58).
+
+    Real Blender: ADD each source group's per-vertex weights into the target group (creating
+    it if absent), then remove the source group. Test fake (vertex_groups is a list[str]):
+    ensure the target name exists and drop the source name. No-op for sources absent on this
+    mesh.
+    """
+    if not merges:
+        return
+    groups = getattr(mesh_obj, "vertex_groups", None)
+    if groups is None:
+        return
+
+    is_fake = isinstance(groups, list) and (not groups or isinstance(groups[0], str))
+    if is_fake:
+        names = groups
+        for merge in merges:
+            src, tgt = merge["source"], merge["target"]
+            if src not in names:
+                continue
+            if tgt not in names:
+                names.append(tgt)
+            names.remove(src)
+        return
+
+    by_name = {g.name: g for g in groups}
+    for merge in merges:
+        src_name, tgt_name = merge["source"], merge["target"]
+        src = by_name.get(src_name)
+        if src is None:
+            continue
+        tgt = by_name.get(tgt_name)
+        if tgt is None:
+            tgt = mesh_obj.vertex_groups.new(name=tgt_name)
+            by_name[tgt_name] = tgt
+        for vert in mesh_obj.data.vertices:
+            for ge in vert.groups:
+                if ge.group == src.index:
+                    tgt.add([vert.index], min(1.0, ge.weight), "ADD")
+                    break
+        mesh_obj.vertex_groups.remove(src)
+        del by_name[src_name]
+
+
+def _purge_unbound_vertex_groups(mesh_obj, bone_names) -> None:
+    """Remove vertex groups whose name is not a bone in the generated armature (#58 cleanup).
+    Runs after renames + merges, so it only drops genuinely dead groups."""
+    groups = getattr(mesh_obj, "vertex_groups", None)
+    if groups is None:
+        return
+    if isinstance(groups, list) and (not groups or isinstance(groups[0], str)):
+        mesh_obj.vertex_groups = [name for name in groups if name in bone_names]
+        return
+    for group in list(groups):
+        if group.name not in bone_names:
+            mesh_obj.vertex_groups.remove(group)
 
 
 def _roll_axis_vector(axis):

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -417,6 +417,41 @@ _SPAN_CHILD = {
 }
 
 
+def _compute_weight_merges(spec_bones, source_bones):
+    """Map each orphaned source deform bone to the nearest ancestor that maps to an ASAM
+    target (#58), so the builder can merge their vertex weights instead of orphaning them.
+
+    Walks up the source-bone hierarchy (source_bones[...]["parent"]). A source bone that is
+    itself a mapped ASAM source, or has no mapped ancestor, produces no entry. Returns a
+    sorted list of {"source", "target"}.
+    """
+    source_to_target = {}
+    for bone in spec_bones:
+        source_name = bone.get("source_bone")
+        target_name = bone.get("name")
+        if (
+            source_name
+            and target_name
+            and bone.get("geometry_source") in SOURCE_NAMED_GEOMETRY_SOURCES
+            and source_name != target_name
+        ):
+            source_to_target.setdefault(source_name, target_name)
+
+    merges = []
+    for name, info in source_bones.items():
+        if name in source_to_target:
+            continue
+        parent = info.get("parent")
+        seen = set()
+        while parent and parent not in seen:
+            seen.add(parent)
+            if parent in source_to_target:
+                merges.append({"source": name, "target": source_to_target[parent]})
+                break
+            parent = (source_bones.get(parent) or {}).get("parent")
+    return sorted(merges, key=lambda m: (m["source"], m["target"]))
+
+
 def _span_core_chains(resolved_geometry, spec_bones, placement_metadata, grp_root_local_origin):
     """Set core-chain bone tails to their child's head so the spine and limbs run upright.
 
@@ -543,6 +578,8 @@ def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones:
 
     # Span the central chain so the spine renders upright (see _span_core_chains / #57).
     _span_core_chains(resolved_geometry, spec["bones"], placement_metadata, grp_root_local_origin)
+
+    spec["weight_merges"] = _compute_weight_merges(spec["bones"], source_bones)
 
     preserved_root = _resolve_preserved_source_root_extra(root_resolution, source_bones)
     if preserved_root is not None:

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -394,9 +394,12 @@ def build_armature_spec_from_asset_dir(asset_dir: Path) -> Tuple[dict, dict, dic
 
 # ASAM central-chain spanning (#57): each of these bones' tail is set to its child's head
 # so the spine renders upright instead of copying short source "link" geometry. Head (no
-# core child) extends along the up axis. Hip is intentionally excluded (already upright and
-# governed by special resolution paths: centered pelvis pair, spine-root pivot reconcile).
+# core child) extends along the up axis. Hip is included for full Root->Hip->Lower_Spine
+# continuity; this is a no-op for the centered-pelvis path (which already sets Hip's tail to
+# Lower_Spine's head) and only moves the tail, never the head, so the pelvis/leg joints and
+# the special resolution paths (centered pelvis pair, spine-root pivot reconcile) are intact.
 _CENTRAL_CHAIN_CHILD = {
+    "Hip": "Lower_Spine",
     "Lower_Spine": "Upper_Spine",
     "Upper_Spine": "Neck",
     "Neck": "Head",

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -412,7 +412,9 @@ def _span_central_chain(resolved_geometry, spec_bones, placement_metadata, grp_r
     """
     up = placement_metadata["up_axis"]
     up_index = int(up["index"])
-    up_sign = int(up.get("sign", 1)) or 1
+    # Trust the upstream validator's sign (consistent with geometry_resolution); a
+    # degenerate 0 yields a no-op Head extension caught by the zero-length guard.
+    up_sign = int(up.get("sign", 1))
 
     def _apply(target, new_tail):
         geom = resolved_geometry[target]

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional, Sequence, Tuple
 from phase3_classifier.classifier import CORE_TARGETS
 
 from asam_human_builder.geometry_resolution import (
+    _asam_roll_align_axis,
     _hip_requires_centered_pelvis_pair,
     _opposite_name_candidates,
     _resolve_preserved_source_root_extra,
@@ -415,6 +416,7 @@ def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones:
         "generated_armature_name": "Armature_{0}".format(asset_name),
         "root_resolution": copy.deepcopy(root_resolution),
         "placement_metadata": copy.deepcopy(placement_metadata),
+        "roll_align_axis": _asam_roll_align_axis(placement_metadata),
         "mesh_binding": copy.deepcopy(build_plan["mesh_binding"]),
         "extras_preserved": copy.deepcopy(build_plan.get("extras_preserved", [])),
         "grp_root_local_origin": list(grp_root_local_origin),

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -392,22 +392,33 @@ def build_armature_spec_from_asset_dir(asset_dir: Path) -> Tuple[dict, dict, dic
     return classifier_report, build_plan, build_armature_spec(classifier_report, build_plan, source_bones)
 
 
-# ASAM central-chain spanning (#57): each of these bones' tail is set to its child's head
-# so the spine renders upright instead of copying short source "link" geometry. Head (no
-# core child) extends along the up axis. Hip is included for full Root->Hip->Lower_Spine
-# continuity; this is a no-op for the centered-pelvis path (which already sets Hip's tail to
-# Lower_Spine's head) and only moves the tail, never the head, so the pelvis/leg joints and
-# the special resolution paths (centered pelvis pair, spine-root pivot reconcile) are intact.
-_CENTRAL_CHAIN_CHILD = {
+# ASAM core-chain spanning (#57, #59): each bone's tail is set to its single core child's
+# head so the spine AND limbs render as connected, upright/extended chains instead of copying
+# short source "link" geometry. Head (no core child) extends along the up axis. Each listed
+# bone has exactly one core child, so there is no multi-child ambiguity. Heads (joints) never
+# move, so rest-pose deformation is unchanged.
+_SPAN_CHILD = {
     "Hip": "Lower_Spine",
     "Lower_Spine": "Upper_Spine",
     "Upper_Spine": "Neck",
     "Neck": "Head",
+    "Shoulder_Left": "Upper_Arm_Left",
+    "Upper_Arm_Left": "Lower_Arm_Left",
+    "Lower_Arm_Left": "Hand_Left",
+    "Shoulder_Right": "Upper_Arm_Right",
+    "Upper_Arm_Right": "Lower_Arm_Right",
+    "Lower_Arm_Right": "Hand_Right",
+    "Upper_Leg_Left": "Lower_Leg_Left",
+    "Lower_Leg_Left": "Foot_Left",
+    "Foot_Left": "Full_Toes_Left",
+    "Upper_Leg_Right": "Lower_Leg_Right",
+    "Lower_Leg_Right": "Foot_Right",
+    "Foot_Right": "Full_Toes_Right",
 }
 
 
-def _span_central_chain(resolved_geometry, spec_bones, placement_metadata, grp_root_local_origin):
-    """Set central-chain bone tails to their child's head so the spine runs upright.
+def _span_core_chains(resolved_geometry, spec_bones, placement_metadata, grp_root_local_origin):
+    """Set core-chain bone tails to their child's head so the spine and limbs run upright.
 
     Heads (joints) never move, which keeps rest-pose deformation unchanged; only tails are
     rewritten. Head, having no core child, extends along the up axis by its default length.
@@ -431,7 +442,7 @@ def _span_central_chain(resolved_geometry, spec_bones, placement_metadata, grp_r
                 bone["tail"] = local_tail
                 break
 
-    for target, child in _CENTRAL_CHAIN_CHILD.items():
+    for target, child in _SPAN_CHILD.items():
         if target in resolved_geometry and child in resolved_geometry:
             _apply(target, list(resolved_geometry[child]["head"]))
 
@@ -530,8 +541,8 @@ def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones:
                     bone["tail"] = _to_grp_root_local(new_tail, grp_root_local_origin)
                     break
 
-    # Span the central chain so the spine renders upright (see _span_central_chain / #57).
-    _span_central_chain(resolved_geometry, spec["bones"], placement_metadata, grp_root_local_origin)
+    # Span the central chain so the spine renders upright (see _span_core_chains / #57).
+    _span_core_chains(resolved_geometry, spec["bones"], placement_metadata, grp_root_local_origin)
 
     preserved_root = _resolve_preserved_source_root_extra(root_resolution, source_bones)
     if preserved_root is not None:

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -13,6 +13,8 @@ from phase3_classifier.classifier import CORE_TARGETS
 
 from asam_human_builder.geometry_resolution import (
     _asam_roll_align_axis,
+    _default_length_for_target,
+    _distance,
     _hip_requires_centered_pelvis_pair,
     _opposite_name_candidates,
     _resolve_preserved_source_root_extra,
@@ -390,6 +392,52 @@ def build_armature_spec_from_asset_dir(asset_dir: Path) -> Tuple[dict, dict, dic
     return classifier_report, build_plan, build_armature_spec(classifier_report, build_plan, source_bones)
 
 
+# ASAM central-chain spanning (#57): each of these bones' tail is set to its child's head
+# so the spine renders upright instead of copying short source "link" geometry. Head (no
+# core child) extends along the up axis. Hip is intentionally excluded (already upright and
+# governed by special resolution paths: centered pelvis pair, spine-root pivot reconcile).
+_CENTRAL_CHAIN_CHILD = {
+    "Lower_Spine": "Upper_Spine",
+    "Upper_Spine": "Neck",
+    "Neck": "Head",
+}
+
+
+def _span_central_chain(resolved_geometry, spec_bones, placement_metadata, grp_root_local_origin):
+    """Set central-chain bone tails to their child's head so the spine runs upright.
+
+    Heads (joints) never move, which keeps rest-pose deformation unchanged; only tails are
+    rewritten. Head, having no core child, extends along the up axis by its default length.
+    A near-zero-length result (child head coincident with this bone's head) is skipped.
+    """
+    up = placement_metadata["up_axis"]
+    up_index = int(up["index"])
+    up_sign = int(up.get("sign", 1)) or 1
+
+    def _apply(target, new_tail):
+        geom = resolved_geometry[target]
+        if _distance(geom["head"], new_tail) <= 1e-6:
+            return
+        geom["tail"] = [float(v) for v in new_tail]
+        geom["length"] = _distance(geom["head"], geom["tail"])
+        local_tail = _to_grp_root_local(geom["tail"], grp_root_local_origin)
+        for bone in spec_bones:
+            if bone["name"] == target:
+                bone["tail"] = local_tail
+                break
+
+    for target, child in _CENTRAL_CHAIN_CHILD.items():
+        if target in resolved_geometry and child in resolved_geometry:
+            _apply(target, list(resolved_geometry[child]["head"]))
+
+    if "Head" in resolved_geometry:
+        head_geom = resolved_geometry["Head"]
+        length = _default_length_for_target("Head", placement_metadata)
+        new_tail = list(head_geom["head"])
+        new_tail[up_index] = head_geom["head"][up_index] + (up_sign * length)
+        _apply("Head", new_tail)
+
+
 def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones: Dict[str, dict]) -> dict:
     """
     Build a deterministic ASAM armature creation spec from classifier outputs.
@@ -476,6 +524,9 @@ def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones:
                 if bone["name"] == "Root":
                     bone["tail"] = _to_grp_root_local(new_tail, grp_root_local_origin)
                     break
+
+    # Span the central chain so the spine renders upright (see _span_central_chain / #57).
+    _span_central_chain(resolved_geometry, spec["bones"], placement_metadata, grp_root_local_origin)
 
     preserved_root = _resolve_preserved_source_root_extra(root_resolution, source_bones)
     if preserved_root is not None:

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -14,8 +14,10 @@ from phase3_classifier.classifier import CORE_TARGETS
 from asam_human_builder.geometry_resolution import (
     _asam_roll_align_axis,
     _default_length_for_target,
+    _direction_vector,
     _distance,
     _hip_requires_centered_pelvis_pair,
+    _offset_point,
     _opposite_name_candidates,
     _resolve_preserved_source_root_extra,
     _resolve_target_geometry,
@@ -452,6 +454,21 @@ def _compute_weight_merges(spec_bones, source_bones):
     return sorted(merges, key=lambda m: (m["source"], m["target"]))
 
 
+def _retarget_tail(resolved_geometry, spec_bones, target, new_tail, grp_root_local_origin):
+    """Rewrite one bone's tail (and the rebased spec tail), leaving its head/joint fixed.
+    Skips a near-zero-length result. Shared by the spanning and terminal-orientation passes."""
+    geom = resolved_geometry[target]
+    if _distance(geom["head"], new_tail) <= 1e-6:
+        return
+    geom["tail"] = [float(v) for v in new_tail]
+    geom["length"] = _distance(geom["head"], geom["tail"])
+    local_tail = _to_grp_root_local(geom["tail"], grp_root_local_origin)
+    for bone in spec_bones:
+        if bone["name"] == target:
+            bone["tail"] = local_tail
+            break
+
+
 def _span_core_chains(resolved_geometry, spec_bones, placement_metadata, grp_root_local_origin):
     """Set core-chain bone tails to their child's head so the spine and limbs run upright.
 
@@ -465,28 +482,44 @@ def _span_core_chains(resolved_geometry, spec_bones, placement_metadata, grp_roo
     # degenerate 0 yields a no-op Head extension caught by the zero-length guard.
     up_sign = int(up.get("sign", 1))
 
-    def _apply(target, new_tail):
-        geom = resolved_geometry[target]
-        if _distance(geom["head"], new_tail) <= 1e-6:
-            return
-        geom["tail"] = [float(v) for v in new_tail]
-        geom["length"] = _distance(geom["head"], geom["tail"])
-        local_tail = _to_grp_root_local(geom["tail"], grp_root_local_origin)
-        for bone in spec_bones:
-            if bone["name"] == target:
-                bone["tail"] = local_tail
-                break
-
     for target, child in _SPAN_CHILD.items():
         if target in resolved_geometry and child in resolved_geometry:
-            _apply(target, list(resolved_geometry[child]["head"]))
+            _retarget_tail(resolved_geometry, spec_bones, target, list(resolved_geometry[child]["head"]), grp_root_local_origin)
 
     if "Head" in resolved_geometry:
         head_geom = resolved_geometry["Head"]
         length = _default_length_for_target("Head", placement_metadata)
         new_tail = list(head_geom["head"])
         new_tail[up_index] = head_geom["head"][up_index] + (up_sign * length)
-        _apply("Head", new_tail)
+        _retarget_tail(resolved_geometry, spec_bones, "Head", new_tail, grp_root_local_origin)
+
+
+# Terminal extremities have no spanned child; orient each one along its (post-spanning)
+# parent's direction at a default length so hands/fingers/thumbs/toes flow out of the limb
+# chain (#60). Ordered so hands are oriented before fingers/thumb (which then follow the
+# oriented hand). Eye_* (forward gaze) and Head (up-extension) are intentionally excluded.
+_TERMINAL_EXTREMITIES = [
+    "Hand_Left", "Hand_Right",
+    "Full_Fingers_Left", "Full_Fingers_Right",
+    "Full_Thumb_Left", "Full_Thumb_Right",
+    "Full_Toes_Left", "Full_Toes_Right",
+]
+
+
+def _orient_terminal_extremities(resolved_geometry, spec_bones, placement_metadata, grp_root_local_origin, bone_parents):
+    """Point each terminal extremity along its parent's direction; head/joint unchanged."""
+    for target in _TERMINAL_EXTREMITIES:
+        if target not in resolved_geometry:
+            continue
+        parent_geom = resolved_geometry.get(bone_parents.get(target))
+        if parent_geom is None:
+            continue
+        direction = _direction_vector(parent_geom["head"], parent_geom["tail"])
+        if _distance([0.0, 0.0, 0.0], direction) <= 1e-6:
+            continue
+        length = _default_length_for_target(target, placement_metadata)
+        new_tail = _offset_point(resolved_geometry[target]["head"], direction, length)
+        _retarget_tail(resolved_geometry, spec_bones, target, new_tail, grp_root_local_origin)
 
 
 def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones: Dict[str, dict]) -> dict:
@@ -578,6 +611,10 @@ def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones:
 
     # Span the central chain so the spine renders upright (see _span_core_chains / #57).
     _span_core_chains(resolved_geometry, spec["bones"], placement_metadata, grp_root_local_origin)
+
+    _orient_terminal_extremities(
+        resolved_geometry, spec["bones"], placement_metadata, grp_root_local_origin, bone_parents
+    )
 
     spec["weight_merges"] = _compute_weight_merges(spec["bones"], source_bones)
 

--- a/src/asam_human_builder/geometry_resolution.py
+++ b/src/asam_human_builder/geometry_resolution.py
@@ -559,3 +559,20 @@ def _resolve_preserved_source_root_extra(
         "source_bone": source_name,
         "semantic_action": "preserve_extra",
     }
+
+
+def _asam_roll_align_axis(placement_metadata: dict) -> List[float]:
+    """World-space unit vector that a bone's local Z should align to under ASAM.
+
+    ASAM OpenMATERIAL human geometry: the bone y-axis follows the bone direction and
+    the z-axis points sidewards (x forward for upright bones, x up for foot/toe bones,
+    which follows automatically). Aligning every generated bone's local Z to the world
+    side axis reproduces that convention uniformly. Returns a unit vector along the
+    placement side axis, signed by side_axis['sign'].
+    """
+    side = placement_metadata["side_axis"]
+    index = int(side["index"])
+    sign = float(side.get("sign", 1)) or 1.0
+    axis = [0.0, 0.0, 0.0]
+    axis[index] = 1.0 if sign >= 0 else -1.0
+    return axis

--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -2098,13 +2098,16 @@ def _runner_up_is_interchangeable(
     - Blender duplicate/twist twins and same-deform-chain segments that share a
       numbered stem ('DEF-spine.004' vs 'DEF-spine.005').
     - Adjacent segments of the same chosen spine chain regardless of digit-naming
-      style ('Spine0' vs 'Spine1', 'mixamorig:Spine' vs 'Spine1'). The stem check
-      above misses these because the digit is concatenated, not a '.NNN' suffix.
-      Chain-position scoring already picks the correct end, so any other segment of
-      the same chain is an interchangeable runner-up.
+      style ('Spine0' vs 'Spine1', 'mixamorig:Spine' vs 'mixamorig:Spine1'). The
+      stem check above misses these because the digit is concatenated, not a '.NNN'
+      suffix. Chain-position scoring already picks the correct end, so any other
+      segment of the same chain is an interchangeable runner-up.
     """
     if _numbered_stem(runner_up.source_bone) == _numbered_stem(candidate.source_bone):
         return True
+    # Only the two spine targets draw candidates from a shared multi-segment chain;
+    # the other 26 core targets map to distinct bones, so the chain-membership relief
+    # is scoped to them. Extend this set if a future target shares a long chain.
     if target_name in {"Lower_Spine", "Upper_Spine"}:
         spine_chain = context.get("spine_chain") or []
         if candidate.source_bone in spine_chain and runner_up.source_bone in spine_chain:

--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -2085,6 +2085,33 @@ def _numbered_stem(name: str) -> str:
     return re.sub(r"\.\d+$", "", name)
 
 
+def _runner_up_is_interchangeable(
+    candidate: CandidateScore,
+    runner_up: CandidateScore,
+    target_name: str,
+    context: dict,
+) -> bool:
+    """True when the runner-up is anatomically interchangeable with the candidate,
+    so a near-zero separation must NOT demote a real mapping to review.
+
+    Covers two cases:
+    - Blender duplicate/twist twins and same-deform-chain segments that share a
+      numbered stem ('DEF-spine.004' vs 'DEF-spine.005').
+    - Adjacent segments of the same chosen spine chain regardless of digit-naming
+      style ('Spine0' vs 'Spine1', 'mixamorig:Spine' vs 'Spine1'). The stem check
+      above misses these because the digit is concatenated, not a '.NNN' suffix.
+      Chain-position scoring already picks the correct end, so any other segment of
+      the same chain is an interchangeable runner-up.
+    """
+    if _numbered_stem(runner_up.source_bone) == _numbered_stem(candidate.source_bone):
+        return True
+    if target_name in {"Lower_Spine", "Upper_Spine"}:
+        spine_chain = context.get("spine_chain") or []
+        if candidate.source_bone in spine_chain and runner_up.source_bone in spine_chain:
+            return True
+    return False
+
+
 def _decision_tag(
     target_name: str,
     candidate: CandidateScore,
@@ -2098,13 +2125,10 @@ def _decision_tag(
 
     separation = 1.0
     if runner_up:
-        # Ignore interchangeable runner-ups that share the candidate's numbered
-        # stem: Blender twist/duplicate twins ('DEF-arm' vs 'DEF-arm.001') and
-        # adjacent segments of one deform chain ('DEF-spine.004' vs 'DEF-spine.005').
-        # Either is anatomically correct, so this zero-separation tie must not
-        # demote a real mapping to review. (Same-chain segments necessarily share
-        # the numbered stem, so the stem check alone covers both cases.)
-        if _numbered_stem(runner_up.source_bone) == _numbered_stem(candidate.source_bone):
+        # Interchangeable runner-ups (numbered twins, or adjacent segments of the
+        # same chosen chain) must not collapse separation and demote a real mapping
+        # to review. See _runner_up_is_interchangeable for the two covered cases.
+        if _runner_up_is_interchangeable(candidate, runner_up, target_name, context):
             separation = 1.0
         else:
             separation = candidate.selection_score - runner_up.selection_score

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -234,6 +234,13 @@ class _FakeBone:
         self.tail = [0.0, 0.0, 0.0]
         self.parent = None
         self.use_connect = False
+        self.roll = 0.0
+        self.roll_aligned_to = None
+
+    def align_roll(self, vector):
+        # Mirror Blender's EditBone.align_roll just enough for assertions: record
+        # the target axis the bone's local Z was aligned to.
+        self.roll_aligned_to = [float(component) for component in vector]
 
 
 class _FakeEditBones:
@@ -2312,6 +2319,34 @@ class ComputeVertexGroupRemapPlanTests(unittest.TestCase):
 
         self.assertEqual(plan["renames"], [{"source": "DEF-hand.L", "target": "Hand_Left"}])
         self.assertEqual(plan["asam_targets_without_source_group"], [])
+
+
+class AsamHumanBuilderRollTests(unittest.TestCase):
+    """Every generated bone (mapped AND synthesized) is roll-aligned to the ASAM
+    side axis so its local Z points sidewards."""
+
+    def test_every_bone_is_roll_aligned_to_side_axis(self):
+        asset_dir = _copy_asset_folder("openmatexamplehuman")
+        write_asset_report(asset_dir)
+        _, build_plan, build_spec = build_armature_spec_from_asset_dir(asset_dir)
+        bpy_module = _FakeBpy()
+        bpy_module.add_source_armature("Armature")
+        for mesh_record in build_plan["mesh_binding"]["meshes"]:
+            bpy_module.add_source_mesh(
+                mesh_record["mesh_name"],
+                bpy_module.data.objects.get("Armature"),
+            )
+        build_armature_in_blender(build_spec, bpy_module)
+
+        expected = build_spec["roll_align_axis"]
+        edit_bones = bpy_module.data.objects.get(
+            build_spec["generated_armature_name"]
+        ).data.edit_bones
+        for bone in build_spec["bones"]:
+            self.assertEqual(
+                edit_bones[bone["name"]].roll_aligned_to, expected,
+                f"{bone['name']} was not roll-aligned to the ASAM side axis",
+            )
 
 
 class CrowdFlatInputsTests(unittest.TestCase):

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -1318,20 +1318,24 @@ class AsamHumanBuilderTests(unittest.TestCase):
             "source_bone": "Root",
             "grp_root_local_origin": [0.0, 0.0, 0.0],
         })
-        report["semantic_mapping"]["Hip"].update({
-            "source_bone": "Hip",
-            "action": "direct_map",
-            "confidence": 1.0,
-        })
+        for target, src in (("Hip", "Hip"), ("Lower_Spine", "Lower_Spine")):
+            report["semantic_mapping"][target].update({
+                "source_bone": src,
+                "action": "direct_map",
+                "confidence": 1.0,
+            })
         source_bones = {
             "Root": _bone("Root", None, (0.0, 0.0, 0.0), (0.0, 0.0, 0.5)),
             "Hip": _bone("Hip", "Root", (0.0, 0.0, 0.9), (0.0, 0.0, 1.0)),
+            "Lower_Spine": _bone("Lower_Spine", "Hip", (0.0, 0.0, 1.0), (0.0, 0.0, 1.1)),
         }
 
         spec = build_armature_spec(report, plan, source_bones)
 
+        # Zero origin -> spec coords are identical to source coords (pass-through).
         hip_bone = _spec_bone(spec, "Hip")
         self.assertEqual(hip_bone["head"], [0.0, 0.0, 0.9])
+        # Hip now spans to Lower_Spine's head (both pass through unchanged at zero origin).
         self.assertEqual(hip_bone["tail"], [0.0, 0.0, 1.0])
 
     def test_reuse_existing_root_keeps_source_position_in_grp_root_local(self):
@@ -2707,13 +2711,17 @@ class CentralChainSpanningTests(unittest.TestCase):
             if axis != up_index:
                 self.assertAlmostEqual(head["tail"][axis], head["head"][axis], places=6)
 
-    def test_hip_is_not_spanned(self):
+    def test_hip_spans_to_lower_spine(self):
         plan = _base_build_plan()
         plan["root_resolutions"][0]["grp_root_local_origin"] = [0.0, 0.0, 0.0]
         spec = build_armature_spec(
             self._report_with_direct_central_chain(), plan, self._short_nub_source_bones()
         )
-        _assert_vec_almost_equal(self, _spec_bone(spec, "Hip")["tail"], [0.0, 0.0, 0.95])
+        src = self._short_nub_source_bones()
+        # Hip tail snaps to Lower_Spine's head (perfect Root->Hip->Lower_Spine continuity)...
+        _assert_vec_almost_equal(self, _spec_bone(spec, "Hip")["tail"], src["Lower_Spine"]["head"])
+        # ...while its head (joint) is unchanged.
+        _assert_vec_almost_equal(self, _spec_bone(spec, "Hip")["head"], src["Hip"]["head"])
 
     def test_zero_length_guard_keeps_source_tail(self):
         plan = _base_build_plan()

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2657,6 +2657,50 @@ class AsamRollAxisTests(unittest.TestCase):
         self.assertEqual(build_spec["roll_align_axis"], expected)
 
 
+class LimbChainSpanningTests(unittest.TestCase):
+    """Arm/leg chains span tail->child-head like the spine (issue #59)."""
+
+    def _report_with_direct_limbs(self):
+        report = _base_classifier_report()
+        for target, src in {
+            "Shoulder_Left": "LClavicle", "Upper_Arm_Left": "LUpperArm",
+            "Lower_Arm_Left": "LForeArm", "Hand_Left": "LHand",
+            "Upper_Leg_Left": "LThigh", "Lower_Leg_Left": "LCalf",
+            "Foot_Left": "LFoot", "Full_Toes_Left": "LToe",
+        }.items():
+            report["semantic_mapping"][target].update(
+                {"source_bone": src, "action": "direct_map", "confidence": 0.95}
+            )
+        return report
+
+    def _gapped_limb_source_bones(self):
+        b = _bone
+        return {
+            "LClavicle": b("LClavicle", None, (0.05, 0.0, 1.45), (0.10, 0.0, 1.45)),
+            "LUpperArm": b("LUpperArm", "LClavicle", (0.18, 0.0, 1.45), (0.22, 0.0, 1.45)),
+            "LForeArm": b("LForeArm", "LUpperArm", (0.45, 0.0, 1.45), (0.50, 0.0, 1.45)),
+            "LHand": b("LHand", "LForeArm", (0.70, 0.0, 1.45), (0.75, 0.0, 1.45)),
+            "LThigh": b("LThigh", None, (0.10, 0.0, 0.95), (0.10, 0.0, 0.90)),
+            "LCalf": b("LCalf", "LThigh", (0.10, 0.0, 0.55), (0.10, 0.0, 0.50)),
+            "LFoot": b("LFoot", "LCalf", (0.10, 0.0, 0.10), (0.15, 0.0, 0.10)),
+            "LToe": b("LToe", "LFoot", (0.20, 0.0, 0.05), (0.25, 0.0, 0.05)),
+        }
+
+    def test_limb_chains_span_to_child_heads(self):
+        plan = _base_build_plan()
+        plan["root_resolutions"][0]["grp_root_local_origin"] = [0.0, 0.0, 0.0]
+        spec = build_armature_spec(
+            self._report_with_direct_limbs(), plan, self._gapped_limb_source_bones()
+        )
+        def head(t): return _spec_bone(spec, t)["head"]
+        for parent, child in [
+            ("Shoulder_Left", "Upper_Arm_Left"), ("Upper_Arm_Left", "Lower_Arm_Left"),
+            ("Lower_Arm_Left", "Hand_Left"), ("Upper_Leg_Left", "Lower_Leg_Left"),
+            ("Lower_Leg_Left", "Foot_Left"), ("Foot_Left", "Full_Toes_Left"),
+        ]:
+            _assert_vec_almost_equal(self, _spec_bone(spec, parent)["tail"], head(child))
+
+
 class CentralChainSpanningTests(unittest.TestCase):
     """The central chain (Lower_Spine, Upper_Spine, Neck, Head) spans to child joints so
     the spine renders upright; heads stay on source joints; Hip is untouched (issue #57)."""

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2789,6 +2789,60 @@ class CentralChainSpanningTests(unittest.TestCase):
         _assert_vec_almost_equal(self, _spec_bone(spec, "Lower_Spine")["tail"], expected)
 
 
+class TerminalExtremityOrientationTests(unittest.TestCase):
+    """Hands/fingers/thumbs/toes point along their (spanned) parent's direction (#60)."""
+
+    def _report(self):
+        report = _base_classifier_report()
+        for target, src in {
+            "Upper_Arm_Left": "LUpperArm", "Lower_Arm_Left": "LForeArm", "Hand_Left": "LHand",
+            "Lower_Leg_Left": "LCalf", "Foot_Left": "LFoot", "Full_Toes_Left": "LToe",
+        }.items():
+            report["semantic_mapping"][target].update(
+                {"source_bone": src, "action": "direct_map", "confidence": 0.95})
+        return report
+
+    def _source_bones(self):
+        b = _bone
+        return {
+            "LUpperArm": b("LUpperArm", None, (0.18, 0, 1.45), (0.22, 0, 1.45)),
+            "LForeArm": b("LForeArm", "LUpperArm", (0.45, 0, 1.45), (0.50, 0, 1.45)),
+            "LHand": b("LHand", "LForeArm", (0.70, 0, 1.45), (0.70, 0, 1.20)),  # source: DOWN
+            "LCalf": b("LCalf", None, (0.10, 0, 0.55), (0.10, 0, 0.50)),
+            "LFoot": b("LFoot", "LCalf", (0.10, 0, 0.10), (0.15, 0, 0.10)),
+            "LToe": b("LToe", "LFoot", (0.20, 0, 0.05), (0.20, 0, 0.20)),       # source: UP
+        }
+
+    def _unit_dir_and_len(self, spec, target):
+        import math
+        bone = _spec_bone(spec, target)
+        v = [bone["tail"][i] - bone["head"][i] for i in range(3)]
+        length = math.sqrt(sum(x * x for x in v)) or 1.0
+        return [x / length for x in v], length
+
+    def test_terminals_follow_parent_direction(self):
+        from asam_human_builder.geometry_resolution import _default_length_for_target
+        plan = _base_build_plan()
+        plan["root_resolutions"][0]["grp_root_local_origin"] = [0.0, 0.0, 0.0]
+        spec = build_armature_spec(self._report(), plan, self._source_bones())
+
+        hand_dir, hand_len = self._unit_dir_and_len(spec, "Hand_Left")
+        forearm_dir, _ = self._unit_dir_and_len(spec, "Lower_Arm_Left")
+        for i in range(3):
+            self.assertAlmostEqual(hand_dir[i], forearm_dir[i], places=5)
+        self.assertAlmostEqual(
+            hand_len, _default_length_for_target("Hand_Left", plan["placement_metadata"]), places=5)
+
+        toe_dir, _ = self._unit_dir_and_len(spec, "Full_Toes_Left")
+        foot_dir, _ = self._unit_dir_and_len(spec, "Foot_Left")
+        for i in range(3):
+            self.assertAlmostEqual(toe_dir[i], foot_dir[i], places=5)
+
+        fingers_dir, _ = self._unit_dir_and_len(spec, "Full_Fingers_Left")
+        for i in range(3):
+            self.assertAlmostEqual(fingers_dir[i], hand_dir[i], places=5)
+
+
 class WeightMergeAndPurgeExecutionTests(unittest.TestCase):
     """Test weight merge and purge execution during mesh duplication (#58 execution)."""
 

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2723,6 +2723,19 @@ class CentralChainSpanningTests(unittest.TestCase):
         spec = build_armature_spec(self._report_with_direct_central_chain(), plan, bones)
         _assert_vec_almost_equal(self, _spec_bone(spec, "Neck")["tail"], bones["Neck"]["tail"])
 
+    def test_spanned_tail_is_rebased_to_grp_root_local(self):
+        # With a non-zero Grp_Root origin, the spanned tail must be the child's source
+        # head expressed in Grp_Root-local coords (exercises the _to_grp_root_local write).
+        origin = [0.0, 0.0, 0.90]
+        plan = _base_build_plan()
+        plan["root_resolutions"][0]["grp_root_local_origin"] = list(origin)
+        spec = build_armature_spec(
+            self._report_with_direct_central_chain(), plan, self._short_nub_source_bones()
+        )
+        child_head = self._short_nub_source_bones()["Upper_Spine"]["head"]
+        expected = [child_head[i] - origin[i] for i in range(3)]
+        _assert_vec_almost_equal(self, _spec_bone(spec, "Lower_Spine")["tail"], expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2595,5 +2595,22 @@ class PlacementDeltaTests(unittest.TestCase):
         self.assertIs(blender_builder._translated_matrix(sentinel, [0.0, 0.0, 0.0]), sentinel)
 
 
+class AsamRollAxisTests(unittest.TestCase):
+    """build_armature_spec exposes the ASAM roll-alignment axis: a unit vector along
+    the world side axis (local bone Z points sidewards per ASAM OpenMATERIAL)."""
+
+    def test_spec_carries_unit_side_axis_roll_vector(self):
+        asset_dir = _copy_asset_folder("openmatexamplehuman")
+        write_asset_report(asset_dir)
+        _, build_plan, build_spec = build_armature_spec_from_asset_dir(asset_dir)
+
+        side = build_plan["placement_metadata"]["side_axis"]
+        index = int(side["index"])
+        expected = [0.0, 0.0, 0.0]
+        expected[index] = 1.0 if float(side.get("sign", 1)) >= 0 else -1.0
+
+        self.assertEqual(build_spec["roll_align_axis"], expected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2789,5 +2789,41 @@ class CentralChainSpanningTests(unittest.TestCase):
         _assert_vec_almost_equal(self, _spec_bone(spec, "Lower_Spine")["tail"], expected)
 
 
+class WeightMergePlanTests(unittest.TestCase):
+    """Orphaned source deform bones merge into their nearest mapped ASAM ancestor (#58)."""
+
+    def _report(self):
+        report = _base_classifier_report()
+        report["semantic_mapping"]["Lower_Spine"].update(
+            {"source_bone": "Spine0", "action": "direct_map", "confidence": 0.95})
+        report["semantic_mapping"]["Upper_Spine"].update(
+            {"source_bone": "Spine3", "action": "direct_map", "confidence": 0.95})
+        return report
+
+    def _source_bones(self):
+        b = _bone
+        return {
+            "Pelvis": b("Pelvis", None, (0, 0, 0.9), (0, 0, 1.0)),
+            "Spine0": b("Spine0", "Pelvis", (0, 0, 1.0), (0, 0, 1.1)),
+            "Spine1": b("Spine1", "Spine0", (0, 0, 1.1), (0, 0, 1.2)),
+            "Spine2": b("Spine2", "Spine1", (0, 0, 1.2), (0, 0, 1.3)),
+            "Spine3": b("Spine3", "Spine2", (0, 0, 1.3), (0, 0, 1.4)),
+            "Spine4": b("Spine4", "Spine3", (0, 0, 1.4), (0, 0, 1.5)),
+            "Floating": b("Floating", None, (5, 5, 5), (5, 5, 5.1)),  # no mapped ancestor
+        }
+
+    def test_weight_merges_resolve_to_nearest_mapped_ancestor(self):
+        plan = _base_build_plan()
+        spec = build_armature_spec(self._report(), plan, self._source_bones())
+        merges = {m["source"]: m["target"] for m in spec["weight_merges"]}
+        self.assertEqual(merges.get("Spine1"), "Lower_Spine")  # ancestor Spine0
+        self.assertEqual(merges.get("Spine2"), "Lower_Spine")  # ancestor Spine0
+        self.assertEqual(merges.get("Spine4"), "Upper_Spine")  # ancestor Spine3
+        self.assertNotIn("Spine0", merges)
+        self.assertNotIn("Spine3", merges)
+        self.assertNotIn("Floating", merges)
+        self.assertEqual(spec["weight_merges"], sorted(spec["weight_merges"], key=lambda m: (m["source"], m["target"])))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2443,6 +2443,12 @@ class CrowdSpecsFromAssetDirTests(unittest.TestCase):
             self.assertEqual(spec["generated_armature_name"], "Armature_crowd_{0}".format(cid))
             # Each character resolves Hip geometry from its OWN bones (no cross-character mixing).
             self.assertTrue(any(b["name"] == "Hip" for b in spec["bones"]))
+            # The ASAM roll-alignment axis must propagate to EVERY character's spec
+            # through the crowd fan-out (build_armature_spec runs per character).
+            side = spec["placement_metadata"]["side_axis"]
+            expected_axis = [0.0, 0.0, 0.0]
+            expected_axis[int(side["index"])] = 1.0 if float(side.get("sign", 1)) >= 0 else -1.0
+            self.assertEqual(spec["roll_align_axis"], expected_axis)
 
     def test_single_character_returns_unchanged_path(self):
         from asam_human_builder.builder import build_character_specs_from_asset_dir

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -1819,7 +1819,7 @@ class CrowdNamingTests(unittest.TestCase):
         self.assertNotIn("unmapped_vertex_groups:BodyMesh", execution_result["mesh_warnings"])
 
     def test_blender_builder_reports_unmapped_vertex_groups(self):
-        """Vertex groups with no ASAM mapping must surface as a mesh_warning."""
+        """Vertex groups with no ASAM mapping are purged (#58)."""
         bpy_module = _FakeBpy()
         source_armature = bpy_module.add_source_armature("Rig")
         source_mesh = bpy_module.add_source_mesh("BodyMesh", source_armature, armature_modifier=True)
@@ -1838,7 +1838,7 @@ class CrowdNamingTests(unittest.TestCase):
 
         generated_mesh = bpy_module.data.objects.get("ASAM_BodyMesh")
         self.assertIn("Hand_Left", generated_mesh.vertex_groups)
-        self.assertIn("MCH-helper_bone", generated_mesh.vertex_groups)  # left alone
+        self.assertNotIn("MCH-helper_bone", generated_mesh.vertex_groups)  # purged (no matching bone)
         self.assertIn("unmapped_vertex_groups:BodyMesh", execution_result["mesh_warnings"])
 
         remap = execution_result["duplicated_meshes"][0]["vertex_group_remap"]
@@ -2787,6 +2787,46 @@ class CentralChainSpanningTests(unittest.TestCase):
         child_head = self._short_nub_source_bones()["Upper_Spine"]["head"]
         expected = [child_head[i] - origin[i] for i in range(3)]
         _assert_vec_almost_equal(self, _spec_bone(spec, "Lower_Spine")["tail"], expected)
+
+
+class WeightMergeAndPurgeExecutionTests(unittest.TestCase):
+    """Test weight merge and purge execution during mesh duplication (#58 execution)."""
+
+    def test_merge_and_purge_leave_only_bone_groups(self):
+        """After merge+purge, only vertex groups matching generated bones remain."""
+        report = _base_classifier_report()
+        report["semantic_mapping"]["Lower_Spine"].update(
+            {"source_bone": "Spine0", "action": "direct_map", "confidence": 0.95})
+        report["semantic_mapping"]["Upper_Spine"].update(
+            {"source_bone": "Spine3", "action": "direct_map", "confidence": 0.95})
+        plan = _base_build_plan()
+        source_bones = {
+            "Spine0": _bone("Spine0", None, (0, 0, 1.0), (0, 0, 1.1)),
+            "Spine1": _bone("Spine1", "Spine0", (0, 0, 1.1), (0, 0, 1.2)),
+            "Spine3": _bone("Spine3", "Spine1", (0, 0, 1.3), (0, 0, 1.4)),
+            "Spine4": _bone("Spine4", "Spine3", (0, 0, 1.4), (0, 0, 1.5)),
+        }
+        spec = build_armature_spec(report, plan, source_bones)
+
+        bpy_module = _FakeBpy()
+        armature = bpy_module.add_source_armature("Rig")
+        mesh = bpy_module.add_source_mesh("BodyMesh", armature)
+        mesh.vertex_groups = ["Spine0", "Spine1", "Spine3", "Spine4", "Other"]
+        spec["mesh_binding"] = {"armature_object_name": "Rig", "meshes": [
+            {"mesh_name": "BodyMesh", "armature_link": "modifier",
+             "modifiers": [{"stack_index": 0, "type": "ARMATURE", "name": "Armature", "object": "Rig"}],
+             "vertex_groups": ["Spine0", "Spine1", "Spine3", "Spine4", "Other"]}]}
+
+        build_armature_in_blender(spec, bpy_module)
+        result_mesh = bpy_module.data.objects.get("ASAM_BodyMesh")
+        groups = set(result_mesh.vertex_groups)
+        self.assertIn("Lower_Spine", groups)
+        self.assertIn("Upper_Spine", groups)
+        self.assertNotIn("Spine1", groups)   # merged into Lower_Spine, removed
+        self.assertNotIn("Spine4", groups)   # merged into Upper_Spine, removed
+        self.assertNotIn("Other", groups)    # purged (no matching bone)
+        bone_names = {b["name"] for b in spec["bones"]}
+        self.assertTrue(groups.issubset(bone_names))
 
 
 class WeightMergePlanTests(unittest.TestCase):

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2653,5 +2653,76 @@ class AsamRollAxisTests(unittest.TestCase):
         self.assertEqual(build_spec["roll_align_axis"], expected)
 
 
+class CentralChainSpanningTests(unittest.TestCase):
+    """The central chain (Lower_Spine, Upper_Spine, Neck, Head) spans to child joints so
+    the spine renders upright; heads stay on source joints; Hip is untouched (issue #57)."""
+
+    def _report_with_direct_central_chain(self):
+        report = _base_classifier_report()
+        for target, src in {
+            "Hip": "Hip",
+            "Lower_Spine": "Lower_Spine",
+            "Upper_Spine": "Upper_Spine",
+            "Neck": "Neck",
+            "Head": "Head",
+        }.items():
+            report["semantic_mapping"][target].update(
+                {"source_bone": src, "action": "direct_map", "confidence": 0.95}
+            )
+        return report
+
+    def _short_nub_source_bones(self):
+        # Vertical Hip; short forward-pointing (-Y) nubs for the rest, with vertical gaps.
+        return {
+            "Hip": _bone("Hip", None, (0.0, 0.0, 0.90), (0.0, 0.0, 0.95)),
+            "Lower_Spine": _bone("Lower_Spine", "Hip", (0.0, 0.05, 0.93), (0.0, -0.03, 0.93)),
+            "Upper_Spine": _bone("Upper_Spine", "Lower_Spine", (0.0, 0.05, 1.20), (0.0, -0.05, 1.20)),
+            "Neck": _bone("Neck", "Upper_Spine", (0.0, 0.05, 1.47), (0.0, -0.06, 1.47)),
+            "Head": _bone("Head", "Neck", (0.0, 0.05, 1.57), (0.0, -0.09, 1.57)),
+        }
+
+    def test_central_chain_spans_to_child_heads(self):
+        plan = _base_build_plan()
+        plan["root_resolutions"][0]["grp_root_local_origin"] = [0.0, 0.0, 0.0]
+        spec = build_armature_spec(
+            self._report_with_direct_central_chain(), plan, self._short_nub_source_bones()
+        )
+        src = self._short_nub_source_bones()
+        _assert_vec_almost_equal(self, _spec_bone(spec, "Lower_Spine")["tail"], src["Upper_Spine"]["head"])
+        _assert_vec_almost_equal(self, _spec_bone(spec, "Upper_Spine")["tail"], src["Neck"]["head"])
+        _assert_vec_almost_equal(self, _spec_bone(spec, "Neck")["tail"], src["Head"]["head"])
+        for target in ("Lower_Spine", "Upper_Spine", "Neck", "Head"):
+            _assert_vec_almost_equal(self, _spec_bone(spec, target)["head"], src[target]["head"])
+
+    def test_head_extends_along_up_axis(self):
+        plan = _base_build_plan()
+        plan["root_resolutions"][0]["grp_root_local_origin"] = [0.0, 0.0, 0.0]
+        up_index = int(plan["placement_metadata"]["up_axis"]["index"])
+        spec = build_armature_spec(
+            self._report_with_direct_central_chain(), plan, self._short_nub_source_bones()
+        )
+        head = _spec_bone(spec, "Head")
+        self.assertGreater(head["tail"][up_index], head["head"][up_index])
+        for axis in range(3):
+            if axis != up_index:
+                self.assertAlmostEqual(head["tail"][axis], head["head"][axis], places=6)
+
+    def test_hip_is_not_spanned(self):
+        plan = _base_build_plan()
+        plan["root_resolutions"][0]["grp_root_local_origin"] = [0.0, 0.0, 0.0]
+        spec = build_armature_spec(
+            self._report_with_direct_central_chain(), plan, self._short_nub_source_bones()
+        )
+        _assert_vec_almost_equal(self, _spec_bone(spec, "Hip")["tail"], [0.0, 0.0, 0.95])
+
+    def test_zero_length_guard_keeps_source_tail(self):
+        plan = _base_build_plan()
+        plan["root_resolutions"][0]["grp_root_local_origin"] = [0.0, 0.0, 0.0]
+        bones = self._short_nub_source_bones()
+        bones["Head"] = _bone("Head", "Neck", (0.0, 0.05, 1.47), (0.0, -0.09, 1.47))  # same head as Neck
+        spec = build_armature_spec(self._report_with_direct_central_chain(), plan, bones)
+        _assert_vec_almost_equal(self, _spec_bone(spec, "Neck")["tail"], bones["Neck"]["tail"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -1585,5 +1585,57 @@ class MissingIntermediateBenchmarkTests(unittest.TestCase):
         self.assertEqual(m["Lower_Leg_Left"]["action"], "create_in_builder")
 
 
+class BipedMultiSpinePromotionTests(unittest.TestCase):
+    """A Biped with a 5-segment spine must map BOTH ASAM spine targets from real
+    source bones, not collapse them to `review` (issue #55, the 1000idles2 case)."""
+
+    def _five_spine_biped_asset(self, name):
+        b = _bone
+        bones = [
+            b("Bip01 Pelvis", None, (0.0, 0.0, 0.95), (0.0, 0.0, 1.0)),
+            b("Bip01 Spine0", "Bip01 Pelvis", (0.0, 0.0, 1.0), (0.0, 0.0, 1.1)),
+            b("Bip01 Spine1", "Bip01 Spine0", (0.0, 0.0, 1.1), (0.0, 0.0, 1.2)),
+            b("Bip01 Spine2", "Bip01 Spine1", (0.0, 0.0, 1.2), (0.0, 0.0, 1.3)),
+            b("Bip01 Spine3", "Bip01 Spine2", (0.0, 0.0, 1.3), (0.0, 0.0, 1.4)),
+            b("Bip01 Spine4", "Bip01 Spine3", (0.0, 0.0, 1.4), (0.0, 0.0, 1.5)),
+            b("Bip01 Neck", "Bip01 Spine4", (0.0, 0.0, 1.5), (0.0, 0.0, 1.6)),
+            b("Bip01 Head", "Bip01 Neck", (0.0, 0.0, 1.6), (0.0, 0.0, 1.75)),
+        ]
+        chains = {
+            "spine": [[
+                "Bip01 Spine0", "Bip01 Spine1", "Bip01 Spine2",
+                "Bip01 Spine3", "Bip01 Spine4",
+            ]],
+            "leg": {"left": [], "right": [], "unsided": []},
+            "arm": {"left": [], "right": [], "unsided": []},
+        }
+        return _write_single_armature_asset(name, "Bip01", bones, chains)
+
+    def test_five_spine_biped_promotes_both_spine_targets(self):
+        asset_dir = self._five_spine_biped_asset("biped5spine")
+        report, _, _, _ = write_asset_report(asset_dir)
+        sm = report["semantic_mapping"]
+        spine_chain = {
+            "Bip01 Spine0", "Bip01 Spine1", "Bip01 Spine2",
+            "Bip01 Spine3", "Bip01 Spine4",
+        }
+        ambiguous = {a["target"] for a in report["ambiguous_targets"]}
+
+        for target in ("Lower_Spine", "Upper_Spine"):
+            self.assertEqual(
+                sm[target]["action"], "direct_map",
+                f"{target} should map directly, not be demoted to review",
+            )
+            self.assertIn(sm[target]["source_bone"], spine_chain)
+            self.assertNotIn(target, ambiguous)
+
+        # Lower spine must sit below upper spine on the up (z) axis.
+        with open(asset_dir / "Bip01_all.json") as f:
+            bones_by_name = {bn["name"]: bn for bn in json.load(f)["bones"]}
+        lower = bones_by_name[sm["Lower_Spine"]["source_bone"]]
+        upper = bones_by_name[sm["Upper_Spine"]["source_bone"]]
+        self.assertLess(lower["head"][2], upper["head"][2])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Makes off-the-shelf rigs (verified on the `1000idles2` 66-character Biped crowd) convert into ASAM humans whose rig is correct, connected, correctly oriented, and fully skinned. Each change is TDD'd and verified live in Blender.

## What changed

**Spine mapping (#55-A).** Multi-segment source spines (`Spine0..Spine4`) were correctly resolved but demoted to `review` and dropped, so the builder synthesized a collapsed spine. Generalized the runner-up interchangeability guard in `_decision_tag` to treat adjacent segments of the same chosen chain as interchangeable (covers concatenated-digit names like `Spine0`/`Spine1`). Strict superset of the prior `.NNN` check -> Rigify single-character output unchanged.

**Bone orientation (#55-B).** Generated bones had no roll. Every bone is now roll-aligned so local Z points sidewards per ASAM OpenMATERIAL (`align_roll` to the placement side axis); the foot/toe X-up case falls out automatically.

**Chain spanning (#57, #59).** Spine, neck, and limb bones copied short source "link" geometry, leaving gaps. They now span tail->child-head (`Hip->Lower_Spine->Upper_Spine->Neck`, `Shoulder->Upper_Arm->Lower_Arm->Hand`, `Upper_Leg->Lower_Leg->Foot->Full_Toes`). Heads/joints never move -> rest-pose deform unchanged.

**Weight consolidation + purge (#58).** Source deform bones with no ASAM target (e.g. `Spine1/2/4`) left ~290 torso vertices weighted to non-existent bones (unbound when posing). Each orphaned group's weights are now merged into its nearest mapped ASAM ancestor; dead/cross-character groups are purged (per mesh: 1717 -> 20 groups, 0 orphans).

**Terminal extremities (#60).** Hands/fingers/thumbs/toes pointed in odd source/synth directions (hand down, toes up). They now follow their spanned parent's direction at a default length. Eyes (forward gaze) and Head (up) are excluded — already correct.

Closes #55, #57, #58, #59, #60. (#56 — single-spine geometric split — remains deferred.)

## Test plan

- [x] `python -m unittest discover tests` — 296 tests green.
- [x] Single-character (Rigify) invariant: classifier change is a superset of the prior guard; existing golden-mapping/regression tests unchanged.
- [x] Live on `1000idles2` (66 characters): two distinct spine bones on real vertebrae; full chain `Root->Hip->...->Head` connected; limb chains connected; bone local-Z sidewards; mesh fully bound (posing `Lower_Spine` moves the whole torso); hands/toes/fingers oriented outward/forward; eyes forward.

## Deploy note

Live verification ran the repo `src` modules directly. To use these fixes through the installed add-on, rebuild the add-on zip (`tools/build_addon.py`) and reinstall after merge.
