### PR TITLE
Add optional dev hot-reload of pipeline modules

### DIFF
--- a/addon/dev_reload.py
+++ b/addon/dev_reload.py
@@ -1,0 +1,33 @@
+"""Dev convenience: drop cached pipeline modules so the next import reflects live src/ edits.
+
+bpy-free so it is unit-testable. Used by the run/build operators when the "Reload pipeline
+code on each run" add-on preference is enabled, removing the need to restart Blender after
+editing src/ under the dev-link junction (see tools/setup_dev_link.ps1).
+"""
+
+from __future__ import annotations
+
+import sys
+
+# Pipeline packages (and loose modules) bundled from src/. The add-on's own package
+# (open_jaywalker and its submodules), bpy, and third-party modules are deliberately NOT
+# purged — only the pipeline code the developer edits.
+_PIPELINE_PREFIXES = ("armature_inspector", "phase3_classifier", "asam_human_builder", "pipeline")
+_PIPELINE_MODULES = ("pipeline_paths",)
+
+
+def purge_pipeline_modules(modules=None):
+    """Delete cached pipeline modules from ``modules`` (defaults to ``sys.modules``).
+
+    Returns the sorted list of purged names. The next ``import`` of these packages reloads
+    them from ``sys.path`` — i.e. the live ``src/`` exposed by the dev-link junction.
+    """
+    modules = sys.modules if modules is None else modules
+    purged = [
+        name
+        for name in list(modules)
+        if name.split(".")[0] in _PIPELINE_PREFIXES or name in _PIPELINE_MODULES
+    ]
+    for name in purged:
+        del modules[name]
+    return sorted(purged)

--- a/addon/operators.py
+++ b/addon/operators.py
@@ -5,12 +5,10 @@ from pathlib import Path
 
 import bpy
 
-from armature_inspector.inspector import inspect_scene
-from phase3_classifier.classifier import write_asset_report
-from pipeline.plan_summary import summarize_plan
+# Pipeline entry points are imported locally inside each operator's execute() so the
+# optional "dev_reload" purge can take effect per run; only the Clean operator needs a
+# module-level import.
 from asam_human_builder.blender_builder import purge_previous_generated_artifacts
-from asam_human_builder.build_runner import run_build
-from asam_human_builder.builder import success_message
 
 
 def _addon_prefs(context):
@@ -30,6 +28,16 @@ class OJ_OT_run_pipeline(bpy.types.Operator):
         prefs = _addon_prefs(context)
         if prefs.output_dir:
             os.environ["OPEN_JAYWALKER_OUTPUT_ROOT"] = bpy.path.abspath(prefs.output_dir)
+
+        if getattr(prefs, "dev_reload", False):
+            from . import dev_reload
+            dev_reload.purge_pipeline_modules()
+        # Import fresh so a dev_reload purge above takes effect this run (otherwise these
+        # resolve to the already-cached modules, identical to the module-level imports).
+        from armature_inspector.inspector import inspect_scene
+        from phase3_classifier.classifier import write_asset_report
+        from pipeline.plan_summary import summarize_plan
+        from asam_human_builder.blender_builder import purge_previous_generated_artifacts
 
         purge_previous_generated_artifacts(bpy)
 
@@ -77,6 +85,12 @@ class OJ_OT_build(bpy.types.Operator):
 
     def execute(self, context):
         settings = context.scene.open_jaywalker
+        prefs = _addon_prefs(context)
+        if getattr(prefs, "dev_reload", False):
+            from . import dev_reload
+            dev_reload.purge_pipeline_modules()
+        from asam_human_builder.build_runner import run_build
+        from asam_human_builder.builder import success_message
         asset_dir = Path(settings.asset_dir)
         context.window.cursor_set('WAIT')
         try:

--- a/addon/prefs.py
+++ b/addon/prefs.py
@@ -14,6 +14,16 @@ class OJAddonPreferences(bpy.types.AddonPreferences):
         default="",
     )
 
+    dev_reload: bpy.props.BoolProperty(
+        name="Reload pipeline code on each run (dev)",
+        description=(
+            "Developer option: before Run/Build, drop cached pipeline modules so live edits "
+            "to src/ (via the dev-link junction) take effect without restarting Blender. "
+            "Leave OFF for a normal zip install."
+        ),
+        default=False,
+    )
+
     # addon updater preferences
     auto_check_update: bpy.props.BoolProperty(
         name="Auto-check for Update",
@@ -54,5 +64,6 @@ class OJAddonPreferences(bpy.types.AddonPreferences):
             text="Blank = default <repo>/output (or an existing OPEN_JAYWALKER_OUTPUT_ROOT).",
             icon='INFO',
         )
+        layout.prop(self, "dev_reload")
         
         addon_updater_ops.update_settings_ui(self, context)

--- a/tests/test_addon_dev_reload.py
+++ b/tests/test_addon_dev_reload.py
@@ -1,0 +1,46 @@
+import sys
+import unittest
+from pathlib import Path
+
+# dev_reload.py is bpy-free; import it as a top-level module (do NOT import the addon
+# package, whose __init__ pulls in bpy).
+ADDON_ROOT = Path(__file__).resolve().parents[1] / "addon"
+if str(ADDON_ROOT) not in sys.path:
+    sys.path.insert(0, str(ADDON_ROOT))
+
+import dev_reload  # noqa: E402
+
+
+class PurgePipelineModulesTests(unittest.TestCase):
+    def test_purges_only_pipeline_modules(self):
+        fake = {
+            "asam_human_builder": object(),
+            "asam_human_builder.builder": object(),
+            "phase3_classifier.classifier": object(),
+            "armature_inspector.inspector": object(),
+            "pipeline.workflow": object(),
+            "pipeline_paths": object(),
+            "open_jaywalker": object(),           # add-on package - keep
+            "open_jaywalker.operators": object(),  # add-on submodule - keep
+            "bpy": object(),                       # keep
+            "numpy": object(),                     # third-party - keep
+        }
+        purged = dev_reload.purge_pipeline_modules(fake)
+        self.assertEqual(
+            purged,
+            sorted([
+                "asam_human_builder",
+                "asam_human_builder.builder",
+                "phase3_classifier.classifier",
+                "armature_inspector.inspector",
+                "pipeline.workflow",
+                "pipeline_paths",
+            ]),
+        )
+        for gone in ("asam_human_builder", "asam_human_builder.builder", "pipeline_paths"):
+            self.assertNotIn(gone, fake)
+        for kept in ("open_jaywalker", "open_jaywalker.operators", "bpy", "numpy"):
+            self.assertIn(kept, fake)
+
+    def test_returns_empty_when_nothing_to_purge(self):
+        self.assertEqual(dev_reload.purge_pipeline_modules({"bpy": object()}), [])


### PR DESCRIPTION
## Summary

Adds a developer convenience so live `src/` edits (via the dev-link junction from `tools/setup_dev_link.ps1`) take effect **without restarting Blender** or reinstalling the add-on.

- New add-on preference **"Reload pipeline code on each run (dev)"** (default **OFF** — release-safe).
- When enabled, the **Run pipeline** and **Build** operators purge cached pipeline modules (`asam_human_builder`, `phase3_classifier`, `armature_inspector`, `pipeline`, `pipeline_paths`) from `sys.modules` and re-import the entry points fresh, so the next run reflects on-disk edits. The add-on's own modules and `bpy` are never purged.
- Purge logic lives in a small, **bpy-free** `addon/dev_reload.py` (`purge_pipeline_modules`) and is unit-tested.

Background: the add-on caches `sys.modules` in a live session, so even with the dev-link junction serving current `src/`, edits previously required a Blender restart. This removes that for the dev loop. (Bundled into the release zip by `build_addon.py` but inert unless the preference is enabled.)

## Test plan

- [x] `python -m unittest discover tests` — 298 tests green (incl. 2 new `purge_pipeline_modules` tests covering "purges only pipeline modules" and "nothing to purge").
- [x] `py_compile` of the three add-on files; `build_addon.py` bundles `dev_reload.py` and the new pref.
- [ ] Manual (one-time restart to load this new operator code): enable the pref, edit `src/`, click **Run** — change reflects with no restart.
