### PR TITLE
Single-spine rigs: synthesize Lower_Spine/Upper_Spine by geometric split (#56)

### DIFF
--- a/src/asam_human_builder/geometry_resolution.py
+++ b/src/asam_human_builder/geometry_resolution.py
@@ -91,6 +91,13 @@ def _resolve_target_geometry(
         )
         return geometry, "centered_pelvis_pair", source_bone_name
 
+    if payload.get("action") == "split_in_builder":
+        split_geometry = _resolve_split_spine_geometry(
+            target_name, payload, source_bones, placement_metadata, warnings
+        )
+        if split_geometry is not None:
+            return split_geometry
+
     if payload.get("action") in RECOVERABLE_ACTIONS and source_bone_name in source_bones:
         return copy.deepcopy(source_bones[source_bone_name]), "source_bone", source_bone_name
 
@@ -282,6 +289,37 @@ def _resolve_root_geometry(
 
     geometry = _ensure_non_zero_geometry(head, tail, placement_metadata)
     return geometry, "root_resolution", source_bone_name
+
+
+def _resolve_split_spine_geometry(
+    target_name: str,
+    payload: dict,
+    source_bones: Dict[str, dict],
+    placement_metadata: dict,
+    warnings: List[str],
+) -> Optional[Tuple[dict, str, Optional[str]]]:
+    """Bisect a single source spine bone at its midpoint (issue #56).
+
+    Lower half -> Lower_Spine, tagged `source_bone` so the mesh's vertex group
+    renames onto it (weights consolidate on the lower half). Upper half ->
+    Upper_Spine, a synthesized structural bone (`split_spine_upper`, no source
+    bone) so the remap planner leaves it unweighted. Returns None when the source
+    bone is missing, so the caller falls through to ordinary synthesis."""
+    source_bone_name = payload.get("source_bone")
+    source_geometry = source_bones.get(source_bone_name) if source_bone_name else None
+    if source_geometry is None:
+        warnings.append("missing_split_source_geometry:{0}->{1}".format(target_name, source_bone_name))
+        return None
+
+    head = [float(v) for v in source_geometry["head"]]
+    tail = [float(v) for v in source_geometry["tail"]]
+    midpoint = [head[i] + 0.5 * (tail[i] - head[i]) for i in range(3)]
+
+    if payload.get("split_half") == "lower":
+        geometry = _ensure_non_zero_geometry(head, midpoint, placement_metadata)
+        return geometry, "source_bone", source_bone_name
+    geometry = _ensure_non_zero_geometry(midpoint, tail, placement_metadata)
+    return geometry, "split_spine_upper", None
 
 
 def _resolve_created_target_geometry(

--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -148,6 +148,10 @@ HEIGHT_BANDS: Dict[str, Tuple[float, float]] = {
 
 AXIS_NAMES = ("x", "y", "z")
 RECOVERABLE_ACTIONS = {"direct_map", "alias_map", "repair_in_builder"}
+SPLIT_ACTION = "split_in_builder"
+# Actions whose source bone is consumed by a generated target (so it must not be
+# preserved as an extra) and which count toward an armature's mapped-target total.
+MAPPED_ACTIONS = RECOVERABLE_ACTIONS | {SPLIT_ACTION}
 ROOT_CENTER_TOLERANCE_RATIO = 0.02
 ROOT_GROUND_TOLERANCE_RATIO = 0.01
 ROOT_TAIL_TO_HIP_TOLERANCE_RATIO = 0.05
@@ -590,11 +594,12 @@ def classify_armature(asset_name: str, armature_input: ArmatureInput) -> dict:
 
     resolved_targets = _resolve_targets(target_candidates, context)
     _reconcile_hip_to_spine_pivot(resolved_targets, context)
+    _plan_single_spine_split(resolved_targets, context)
     root_resolution = _resolve_root_compliance(resolved_targets, target_candidates.get("Root", []), context)
     mapped_bones = {
         payload["source_bone"]
         for payload in resolved_targets.values()
-        if payload["source_bone"] is not None and payload["action"] in RECOVERABLE_ACTIONS
+        if payload["source_bone"] is not None and payload["action"] in MAPPED_ACTIONS
     }
 
     extras_preserved, unclassified_bones = _classify_non_mapped_bones(bones, context, mapped_bones)
@@ -1436,6 +1441,34 @@ def _classify_non_mapped_bones(
             unclassified.append(payload)
 
     return preserved, unclassified
+
+
+def _plan_single_spine_split(resolved_targets: Dict[str, dict], context: dict) -> None:
+    """Plan a geometric midpoint split of a lone spine bone (issue #56).
+
+    Trigger: the chosen spine chain has exactly one usable bone AND Hip and Neck
+    are already classified. By then the in-between bone is unambiguously spine
+    (topology brackets it), so both ASAM spine targets are pointed at it and tagged
+    `split_in_builder`; the builder bisects it at its midpoint. No-op for 0 or >=2
+    spine bones, or when Hip/Neck are not classified (no bracket -> existing
+    fallback). Mutates `resolved_targets` in place."""
+    spine_chain = context.get("spine_chain") or []
+    if len(spine_chain) != 1:
+        return
+    if resolved_targets["Hip"]["action"] not in RECOVERABLE_ACTIONS:
+        return
+    if resolved_targets["Neck"]["action"] not in {"direct_map", "alias_map"}:
+        return
+
+    spine_bone = spine_chain[0]
+    for target, half in (("Lower_Spine", "lower"), ("Upper_Spine", "upper")):
+        payload = resolved_targets[target]
+        payload["action"] = SPLIT_ACTION
+        payload["source_bone"] = spine_bone
+        payload["split_half"] = half
+        payload["confidence"] = 0.7
+        if "single_spine_geometric_split" not in payload["notes"]:
+            payload["notes"].append("single_spine_geometric_split")
 
 
 def _build_review_flags(resolved_targets: Dict[str, dict], root_resolution: dict, context: dict) -> List[str]:

--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -457,14 +457,29 @@ def classify_asset_folder(asset_dir: Path) -> Tuple[dict, dict]:
 
 
 def _build_actions(asam_targets: Dict[str, dict]) -> Dict[str, list]:
-    actions: Dict[str, list] = {"rename": [], "create": []}
+    actions: Dict[str, list] = {"rename": [], "create": [], "split": []}
+    split_pending: Dict[str, dict] = {}
     for target, payload in asam_targets.items():
         if target == "Root":
             continue
         if payload["action"] in {"direct_map", "alias_map"} and payload["source_bone"]:
             actions["rename"].append({"source": payload["source_bone"], "target": target})
+        elif payload["action"] == SPLIT_ACTION:
+            entry = split_pending.setdefault(
+                payload["source_bone"],
+                {"source": payload["source_bone"], "lower_target": None,
+                 "upper_target": None, "ratio": 0.5},
+            )
+            if payload.get("split_half") == "lower":
+                entry["lower_target"] = target
+            else:
+                entry["upper_target"] = target
         elif payload["action"] == "create_in_builder":
             actions["create"].append({"target": target, "parent": TARGET_PARENTS.get(target)})
+    actions["split"] = [
+        entry for entry in split_pending.values()
+        if entry["lower_target"] and entry["upper_target"]
+    ]
     return actions
 
 

--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -1591,7 +1591,7 @@ def _build_armature_summary(
     armature_name: str,
     name_quality: float,
 ) -> dict:
-    mapped = [payload for payload in resolved_targets.values() if payload["action"] in RECOVERABLE_ACTIONS]
+    mapped = [payload for payload in resolved_targets.values() if payload["action"] in MAPPED_ACTIONS]
     average_confidence = round(sum(payload["confidence"] for payload in mapped) / max(len(mapped), 1), 3)
     direct_map_targets = sum(1 for payload in resolved_targets.values() if payload["action"] == "direct_map")
     alias_map_targets = sum(1 for payload in resolved_targets.values() if payload["action"] == "alias_map")

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2968,6 +2968,52 @@ class SingleSpineSplitBuilderTests(unittest.TestCase):
         self.assertEqual(lower["semantic_action"], "split_in_builder")
         self.assertEqual(upper["semantic_action"], "split_in_builder")
 
+    def test_resolve_split_geometry_bisects_at_true_midpoint(self):
+        # Unit-test the pure resolver in source-world coords, before the builder's
+        # Grp_Root rebase and _span_core_chains run. This pins the 50% split
+        # itself (the spec-level join assertion above is forced equal by spanning
+        # regardless of ratio, so it cannot catch a wrong midpoint).
+        from asam_human_builder.geometry_resolution import _resolve_split_spine_geometry
+
+        source_bones = {
+            "Spine": {"name": "Spine", "parent": "Hips",
+                      "head": [0.0, 0.0, 1.0], "tail": [0.0, 0.0, 1.4], "length": 0.4},
+        }
+        pm = _placement_metadata()
+        warnings = []
+        lower_geom, lower_src, lower_bone = _resolve_split_spine_geometry(
+            "Lower_Spine",
+            {"action": "split_in_builder", "source_bone": "Spine", "split_half": "lower"},
+            source_bones, pm, warnings,
+        )
+        upper_geom, upper_src, upper_bone = _resolve_split_spine_geometry(
+            "Upper_Spine",
+            {"action": "split_in_builder", "source_bone": "Spine", "split_half": "upper"},
+            source_bones, pm, warnings,
+        )
+        # Lower: source head (1.0) -> midpoint (1.2); Upper: midpoint (1.2) -> tail (1.4).
+        self.assertAlmostEqual(lower_geom["head"][2], 1.0, places=6)
+        self.assertAlmostEqual(lower_geom["tail"][2], 1.2, places=6)
+        self.assertAlmostEqual(upper_geom["head"][2], 1.2, places=6)
+        self.assertAlmostEqual(upper_geom["tail"][2], 1.4, places=6)
+        self.assertEqual((lower_src, lower_bone), ("source_bone", "Spine"))
+        self.assertEqual((upper_src, upper_bone), ("split_spine_upper", None))
+        self.assertEqual(warnings, [])
+
+    def test_resolve_split_geometry_missing_source_returns_none_with_warning(self):
+        from asam_human_builder.geometry_resolution import _resolve_split_spine_geometry
+
+        warnings = []
+        result = _resolve_split_spine_geometry(
+            "Lower_Spine",
+            {"action": "split_in_builder", "source_bone": "Ghost", "split_half": "lower"},
+            {}, _placement_metadata(), warnings,
+        )
+        self.assertIsNone(result)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("missing_split_source_geometry", warnings[0])
+        self.assertIn("Ghost", warnings[0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -3024,5 +3024,149 @@ class SingleSpineSplitBuilderTests(unittest.TestCase):
         self.assertEqual(plan_remap["name_collisions"], [])
 
 
+def _write_single_spine_asset_on_disk(asset_name: str = "single_spine_integration") -> Path:
+    """Write a single-spine asset to disk in the inspector-export layout the
+    classifier consumes (mirrors test_phase3_classifier.SingleSpineSplitTests.
+    _single_spine_asset / _write_single_armature_asset).
+
+    The one addition is a `mesh_binding`: the classifier-side helper omits it, but
+    the builder's `validate_builder_inputs` requires `build_plan.mesh_binding` to be
+    a dict whose `armature_object_name` matches `recommended_primary_armature`. Adding
+    it here lets a single asset_dir satisfy BOTH the classifier's write_asset_report
+    and the builder's build_armature_spec_from_asset_dir, so the whole pipeline runs
+    off the same files on disk. The source export stays at `Rig_all.json`, exactly
+    where build_source_bone_index_from_export looks for the primary armature."""
+    bones = [
+        _bone("Hips", None, (0.0, 0.0, 0.95), (0.0, 0.0, 1.0)),
+        _bone("Spine", "Hips", (0.0, 0.0, 1.0), (0.0, 0.0, 1.4)),
+        _bone("LeftUpLeg", "Hips", (0.1, 0.0, 0.95), (0.1, 0.0, 0.5)),
+        _bone("LeftLeg", "LeftUpLeg", (0.1, 0.0, 0.5), (0.1, 0.0, 0.1)),
+        _bone("LeftFoot", "LeftLeg", (0.1, 0.0, 0.1), (0.1, 0.1, 0.05)),
+        _bone("RightUpLeg", "Hips", (-0.1, 0.0, 0.95), (-0.1, 0.0, 0.5)),
+        _bone("RightLeg", "RightUpLeg", (-0.1, 0.0, 0.5), (-0.1, 0.0, 0.1)),
+        _bone("RightFoot", "RightLeg", (-0.1, 0.0, 0.1), (-0.1, 0.1, 0.05)),
+        _bone("Neck", "Spine", (0.0, 0.0, 1.4), (0.0, 0.0, 1.5)),
+        _bone("Head", "Neck", (0.0, 0.0, 1.5), (0.0, 0.0, 1.65)),
+    ]
+    chains = {
+        "spine": [["Spine"]],
+        "leg": {
+            "left": ["LeftUpLeg", "LeftLeg", "LeftFoot"],
+            "right": ["RightUpLeg", "RightLeg", "RightFoot"],
+            "unsided": [],
+        },
+        "arm": {"left": [], "right": [], "unsided": []},
+    }
+    vertex_groups = [bone["name"] for bone in bones]
+    mesh_binding = {
+        "armature_object_name": "Rig",
+        "meshes": [
+            {
+                "mesh_name": "BodyMesh",
+                "armature_link": "modifier",
+                "modifiers": [
+                    {"stack_index": 0, "type": "ARMATURE", "name": "Armature", "object": "Rig"}
+                ],
+                "vertex_groups": vertex_groups,
+                "vertex_group_stats": {
+                    "non_empty_group_count": len(vertex_groups),
+                    "per_group": [
+                        {"name": name, "weighted_vertex_count": 8} for name in vertex_groups
+                    ],
+                },
+                "material_slots": [],
+                "warnings": [],
+            }
+        ],
+    }
+
+    hierarchy = {bone["name"]: [] for bone in bones}
+    for bone in bones:
+        parent = bone["parent"]
+        if parent in hierarchy:
+            hierarchy[parent].append(bone["name"])
+
+    asset_dir = Path(tempfile.mkdtemp(prefix="single_spine_integration_")) / asset_name
+    asset_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "armature_name": "Rig",
+        "source_file": "{0}.blend".format(asset_name),
+        "filter": None,
+        "bone_count": len(bones),
+        "hierarchy": hierarchy,
+        "bones": bones,
+        "chains": chains,
+        "mesh_binding": mesh_binding,
+    }
+    (asset_dir / "Rig_all.json").write_text(_json.dumps(payload), encoding="utf-8")
+    return asset_dir
+
+
+class SingleSpineSplitPipelineIntegrationTests(unittest.TestCase):
+    """End-to-end on-disk seam for the single-spine geometric split (#56).
+
+    The classifier-side tests (test_phase3_classifier.SingleSpineSplitTests) stop at
+    the produced report/plan, and the builder-side tests (SingleSpineSplitBuilderTests)
+    feed build_armature_spec hand-built inputs. NOTHING else runs the REAL classifier
+    on a single-spine asset and then loads its classifier_report.json + build_plan.json
+    back through the builder's disk path. This test wires both halves together via
+    build_armature_spec_from_asset_dir to confirm the full pipeline yields two distinct
+    spine bones, parented Hip -> Lower_Spine -> Upper_Spine -> Neck, with the source
+    Spine bone consumed (not leaked as a preserved extra) and its weights consolidated
+    on Lower_Spine."""
+
+    def test_full_pipeline_splits_single_spine_into_two_bones(self):
+        asset_dir = _write_single_spine_asset_on_disk()
+
+        # Phase 3: the REAL classifier writes classifier_report.json + build_plan.json
+        # into asset_dir. Pin that it actually planned the split for this asset.
+        _report, build_plan, _report_path, _plan_path = write_asset_report(asset_dir)
+        self.assertEqual(
+            build_plan["actions"]["split"],
+            [{"source": "Spine", "lower_target": "Lower_Spine",
+              "upper_target": "Upper_Spine", "ratio": 0.5}],
+        )
+
+        # Builder: consume the SAME asset_dir off disk (report + plan + Rig_all.json).
+        loaded_report, loaded_plan, build_spec = build_armature_spec_from_asset_dir(asset_dir)
+        self.assertEqual(loaded_plan["recommended_primary_armature"], "Rig")
+        self.assertEqual(loaded_report["recommended_primary_armature"], "Rig")
+
+        lower = _spec_bone(build_spec, "Lower_Spine")
+        upper = _spec_bone(build_spec, "Upper_Spine")
+        neck = _spec_bone(build_spec, "Neck")
+
+        # Two DISTINCT spine bones, not one mapped + one collapsed/synthesized clone.
+        self.assertIsNot(lower, upper)
+        self.assertNotEqual(lower["head"], upper["head"])
+
+        # Parented Hip -> Lower_Spine -> Upper_Spine -> Neck.
+        self.assertEqual(lower["parent_bone"], "Hip")
+        self.assertEqual(upper["parent_bone"], "Lower_Spine")
+        self.assertEqual(neck["parent_bone"], "Upper_Spine")
+
+        # The lower half keeps the source Spine geometry; the upper half is structural.
+        self.assertEqual(lower["source_bone"], "Spine")
+        self.assertEqual(lower["geometry_source"], "source_bone")
+        self.assertIsNone(upper["source_bone"])
+
+        # The source "Spine" bone is consumed by the split, never leaked as an extra.
+        spec_bone_names = [bone["name"] for bone in build_spec["bones"]]
+        self.assertNotIn("Spine", spec_bone_names)
+        extras = build_spec.get("extras_preserved", [])
+        extra_names = {
+            entry.get("name") if isinstance(entry, dict) else entry for entry in extras
+        }
+        self.assertNotIn("Spine", extra_names)
+
+        # Weights consolidate on Lower_Spine: the Spine vertex group renames onto
+        # Lower_Spine only, never onto Upper_Spine.
+        remap = compute_vertex_group_remap_plan(build_spec["bones"], ["Spine"])
+        renames = {entry["source"]: entry["target"] for entry in remap["renames"]}
+        self.assertEqual(renames.get("Spine"), "Lower_Spine")
+        self.assertNotIn("Upper_Spine", renames.values())
+        self.assertEqual(remap["name_collisions"], [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -3014,6 +3014,15 @@ class SingleSpineSplitBuilderTests(unittest.TestCase):
         self.assertIn("missing_split_source_geometry", warnings[0])
         self.assertIn("Ghost", warnings[0])
 
+    def test_split_consolidates_weights_on_lower_spine(self):
+        report, plan, source_bones = self._split_inputs()
+        spec = build_armature_spec(report, plan, source_bones)
+        plan_remap = compute_vertex_group_remap_plan(spec["bones"], ["Spine"])
+        renames = {entry["source"]: entry["target"] for entry in plan_remap["renames"]}
+        self.assertEqual(renames.get("Spine"), "Lower_Spine")
+        self.assertNotIn("Upper_Spine", renames.values())
+        self.assertEqual(plan_remap["name_collisions"], [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -2919,5 +2919,55 @@ class WeightMergePlanTests(unittest.TestCase):
         self.assertEqual(spec["weight_merges"], sorted(spec["weight_merges"], key=lambda m: (m["source"], m["target"])))
 
 
+def _minimal_report_and_plan(extra_mapping: dict):
+    """Return a valid (classifier_report, build_plan) pair with extra_mapping overlaid.
+
+    Starts from the full-baseline helpers (_base_classifier_report / _base_build_plan)
+    which already cover all 28 CORE_TARGETS, then overlays any entries in extra_mapping
+    so callers only need to supply the targets they care about.
+    """
+    report = _base_classifier_report()
+    plan = _base_build_plan()
+    for target, payload in extra_mapping.items():
+        report["semantic_mapping"][target] = payload
+    return report, plan
+
+
+class SingleSpineSplitBuilderTests(unittest.TestCase):
+    """The builder bisects a lone source spine bone: lower half -> Lower_Spine
+    (keeps the source bone's weights), upper half -> Upper_Spine (structural)."""
+
+    def _split_inputs(self):
+        source_bones = {
+            "Spine": {"name": "Spine", "parent": "Hips",
+                      "head": [0.0, 0.0, 1.0], "tail": [0.0, 0.0, 1.4], "length": 0.4},
+        }
+        def spine_payload(half):
+            return {"action": "split_in_builder", "source_bone": "Spine",
+                    "split_half": half, "confidence": 0.7, "notes": []}
+        report, plan = _minimal_report_and_plan(
+            extra_mapping={
+                "Lower_Spine": spine_payload("lower"),
+                "Upper_Spine": spine_payload("upper"),
+            },
+        )
+        return report, plan, source_bones
+
+    def test_split_creates_two_half_bones_at_midpoint(self):
+        report, plan, source_bones = self._split_inputs()
+        spec = build_armature_spec(report, plan, source_bones)
+        lower = _spec_bone(spec, "Lower_Spine")
+        upper = _spec_bone(spec, "Upper_Spine")
+        self.assertAlmostEqual(lower["tail"][2], upper["head"][2], places=5)
+        self.assertLess(lower["head"][2], lower["tail"][2])
+        self.assertLess(upper["head"][2], upper["tail"][2])
+        self.assertEqual(lower["geometry_source"], "source_bone")
+        self.assertEqual(lower["source_bone"], "Spine")
+        self.assertEqual(upper["geometry_source"], "split_spine_upper")
+        self.assertIsNone(upper["source_bone"])
+        self.assertEqual(lower["semantic_action"], "split_in_builder")
+        self.assertEqual(upper["semantic_action"], "split_in_builder")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -1699,6 +1699,28 @@ class SingleSpineSplitTests(unittest.TestCase):
         rename_sources = {entry["source"] for entry in build_plan["actions"]["rename"]}
         self.assertNotIn("Spine", rename_sources)
 
+    def test_multi_spine_does_not_split(self):
+        b = _bone
+        bones = [
+            b("Bip01 Pelvis", None, (0.0, 0.0, 0.95), (0.0, 0.0, 1.0)),
+            b("Bip01 Spine0", "Bip01 Pelvis", (0.0, 0.0, 1.0), (0.0, 0.0, 1.1)),
+            b("Bip01 Spine1", "Bip01 Spine0", (0.0, 0.0, 1.1), (0.0, 0.0, 1.2)),
+            b("Bip01 Spine2", "Bip01 Spine1", (0.0, 0.0, 1.2), (0.0, 0.0, 1.3)),
+            b("Bip01 Neck", "Bip01 Spine2", (0.0, 0.0, 1.3), (0.0, 0.0, 1.4)),
+            b("Bip01 Head", "Bip01 Neck", (0.0, 0.0, 1.4), (0.0, 0.0, 1.55)),
+        ]
+        chains = {
+            "spine": [["Bip01 Spine0", "Bip01 Spine1", "Bip01 Spine2"]],
+            "leg": {"left": [], "right": [], "unsided": []},
+            "arm": {"left": [], "right": [], "unsided": []},
+        }
+        asset_dir = _write_single_armature_asset("multispine_nosplit", "Bip01", bones, chains)
+        report, build_plan, _r, _pp = write_asset_report(asset_dir)
+        sm = report["semantic_mapping"]
+        self.assertNotEqual(sm["Lower_Spine"]["action"], "split_in_builder")
+        self.assertNotEqual(sm["Upper_Spine"]["action"], "split_in_builder")
+        self.assertEqual(build_plan["actions"]["split"], [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -1679,6 +1679,9 @@ class SingleSpineSplitTests(unittest.TestCase):
         self.assertNotIn("Spine", [b["bone_name"] for b in report["unclassified_bones"]])
         self.assertNotIn("Lower_Spine", {a["target"] for a in report["ambiguous_targets"]})
         self.assertNotIn("Upper_Spine", report["missing_targets"])
+        # The split resolves both spine targets, so the rig is not flagged as
+        # missing its spine chain.
+        self.assertNotIn("missing_spine_chain", report["review_flags"])
 
     def test_single_spine_without_neck_does_not_split(self):
         asset_dir = self._single_spine_asset("single_spine_no_neck", include_neck=False)

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -1676,7 +1676,7 @@ class SingleSpineSplitTests(unittest.TestCase):
             self.assertEqual(sm[target]["action"], "split_in_builder", target)
             self.assertEqual(sm[target]["source_bone"], "Spine", target)
             self.assertEqual(sm[target]["split_half"], half, target)
-        self.assertNotIn("Spine", report["unclassified_bones"])
+        self.assertNotIn("Spine", [b["bone_name"] for b in report["unclassified_bones"]])
         self.assertNotIn("Lower_Spine", {a["target"] for a in report["ambiguous_targets"]})
         self.assertNotIn("Upper_Spine", report["missing_targets"])
 

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -1637,5 +1637,56 @@ class BipedMultiSpinePromotionTests(unittest.TestCase):
         self.assertLess(lower["head"][2], upper["head"][2])
 
 
+class SingleSpineSplitTests(unittest.TestCase):
+    """A rig with a single usable spine bone bracketed by a classified Hip and
+    Neck must plan a geometric midpoint split into Lower_Spine + Upper_Spine
+    (issue #56), instead of mapping one and synthesizing/collapsing the other."""
+
+    def _single_spine_asset(self, name, *, include_neck=True):
+        b = _bone
+        bones = [
+            b("Hips", None, (0.0, 0.0, 0.95), (0.0, 0.0, 1.0)),
+            b("Spine", "Hips", (0.0, 0.0, 1.0), (0.0, 0.0, 1.4)),
+            b("LeftUpLeg", "Hips", (0.1, 0.0, 0.95), (0.1, 0.0, 0.5)),
+            b("LeftLeg", "LeftUpLeg", (0.1, 0.0, 0.5), (0.1, 0.0, 0.1)),
+            b("LeftFoot", "LeftLeg", (0.1, 0.0, 0.1), (0.1, 0.1, 0.05)),
+            b("RightUpLeg", "Hips", (-0.1, 0.0, 0.95), (-0.1, 0.0, 0.5)),
+            b("RightLeg", "RightUpLeg", (-0.1, 0.0, 0.5), (-0.1, 0.0, 0.1)),
+            b("RightFoot", "RightLeg", (-0.1, 0.0, 0.1), (-0.1, 0.1, 0.05)),
+        ]
+        if include_neck:
+            bones += [
+                b("Neck", "Spine", (0.0, 0.0, 1.4), (0.0, 0.0, 1.5)),
+                b("Head", "Neck", (0.0, 0.0, 1.5), (0.0, 0.0, 1.65)),
+            ]
+        chains = {
+            "spine": [["Spine"]],
+            "leg": {"left": ["LeftUpLeg", "LeftLeg", "LeftFoot"],
+                    "right": ["RightUpLeg", "RightLeg", "RightFoot"],
+                    "unsided": []},
+            "arm": {"left": [], "right": [], "unsided": []},
+        }
+        return _write_single_armature_asset(name, "Rig", bones, chains)
+
+    def test_single_spine_plans_split_for_both_targets(self):
+        asset_dir = self._single_spine_asset("single_spine")
+        report, _, _, _ = write_asset_report(asset_dir)
+        sm = report["semantic_mapping"]
+        for target, half in (("Lower_Spine", "lower"), ("Upper_Spine", "upper")):
+            self.assertEqual(sm[target]["action"], "split_in_builder", target)
+            self.assertEqual(sm[target]["source_bone"], "Spine", target)
+            self.assertEqual(sm[target]["split_half"], half, target)
+        self.assertNotIn("Spine", report["unclassified_bones"])
+        self.assertNotIn("Lower_Spine", {a["target"] for a in report["ambiguous_targets"]})
+        self.assertNotIn("Upper_Spine", report["missing_targets"])
+
+    def test_single_spine_without_neck_does_not_split(self):
+        asset_dir = self._single_spine_asset("single_spine_no_neck", include_neck=False)
+        report, _, _, _ = write_asset_report(asset_dir)
+        sm = report["semantic_mapping"]
+        self.assertNotEqual(sm["Lower_Spine"]["action"], "split_in_builder")
+        self.assertNotEqual(sm["Upper_Spine"]["action"], "split_in_builder")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -1687,6 +1687,18 @@ class SingleSpineSplitTests(unittest.TestCase):
         self.assertNotEqual(sm["Lower_Spine"]["action"], "split_in_builder")
         self.assertNotEqual(sm["Upper_Spine"]["action"], "split_in_builder")
 
+    def test_single_spine_emits_split_action_in_build_plan(self):
+        asset_dir = self._single_spine_asset("single_spine_action")
+        _report, build_plan, _r, _pp = write_asset_report(asset_dir)
+        self.assertIn("split", build_plan["actions"])
+        self.assertEqual(
+            build_plan["actions"]["split"],
+            [{"source": "Spine", "lower_target": "Lower_Spine",
+              "upper_target": "Upper_Spine", "ratio": 0.5}],
+        )
+        rename_sources = {entry["source"] for entry in build_plan["actions"]["rename"]}
+        self.assertNotIn("Spine", rename_sources)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #56.

## Summary

Implements #56. When an off-the-shelf rig exposes only **one** usable spine bone between hip and neck (minimal Mixamo-style / low-poly rigs), the pipeline now deterministically produces both ASAM `Lower_Spine` and `Upper_Spine` by bisecting that bone at its midpoint — instead of mapping one and collapsing the other.

**Classifier plans, builder executes:**
- **Classifier** (`_plan_single_spine_split`): when the chosen spine chain has exactly one bone *and* Hip and Neck are already classified, both ASAM spine targets are tagged `split_in_builder` pointing at that bone (`split_half` lower/upper). A `split` action is emitted into `build_plan.json`, and the source bone is counted as mapped (not leaked as a preserved extra). The topology bracket (Hip below, Neck above) makes the in-between bone unambiguously spine — no name-based guessing.
- **Builder** (`_resolve_split_spine_geometry`): bisects the source bone at its midpoint. Lower half → `Lower_Spine` (keeps the source `geometry_source`, so the mesh vertex group renames onto it — weights consolidate here). Upper half → `Upper_Spine`, a structural/unweighted bone. Re-parenting `Hip→Lower_Spine→Upper_Spine→Neck` and ASAM roll come for free from the existing fixed hierarchy and the #55 orientation pass.

**Invariant preserved:** the split only fires for a single-bone spine chain (`len(spine_chain) == 1`). Multi-bone-spine and single-character rigs take an unchanged path — guarded by a regression test; all pre-existing fixtures are untouched.

## Test Plan

- [x] `python -m unittest discover tests` green (307 tests)
- [x] Classifier: single-spine rig plans the split; missing Hip/Neck or multi-bone spine does **not** split
- [x] Builder: source bone bisected at the true 50% midpoint; missing-source fallback warns and falls through
- [x] Weights consolidate on `Lower_Spine`; `Upper_Spine` unweighted
- [x] End-to-end: real classifier output fed through `build_armature_spec_from_asset_dir` yields two distinct spine bones parented `Hip→Lower_Spine→Upper_Spine→Neck`