### PR TITLE
Anatomical placement for synthesized eyes & fingers (#64)

### DIFF
--- a/src/asam_human_builder/geometry_resolution.py
+++ b/src/asam_human_builder/geometry_resolution.py
@@ -61,6 +61,12 @@ DEFAULT_LENGTH_RATIOS = {
     "Full_Toes_Right": 0.05,
 }
 
+# Eye placement ratios (fractions of Head bone length), issue #64.
+EYE_LEVEL_RATIO = 0.5     # fraction along the Head bone (base->crown) for eye level
+EYE_FORWARD_RATIO = 0.5   # forward offset onto the face
+EYE_SEP_RATIO = 0.3       # lateral half-separation between the two eyes
+EYE_LEN_RATIO = 0.15      # eye bone length (forward/gaze)
+
 
 def _resolve_target_geometry(
     target_name: str,
@@ -322,6 +328,31 @@ def _resolve_split_spine_geometry(
     return geometry, "split_spine_upper", None
 
 
+def _resolve_eye_geometry(
+    target_name: str,
+    head_geometry: dict,
+    placement_metadata: dict,
+) -> Tuple[dict, str, None]:
+    """Anchor a synthesized eye to the Head bone (issue #64): eye level along the
+    Head bone, offset forward onto the face, split laterally so Eye_Left/Eye_Right
+    are distinct. Bone points forward (gaze); X resolves up via the roll pass."""
+    head_pt = [float(v) for v in head_geometry["head"]]
+    head_tail = [float(v) for v in head_geometry["tail"]]
+    head_len = _distance(head_pt, head_tail)
+    if head_len <= 1e-6:
+        head_len = max(float(placement_metadata.get("bbox_height", 0.0)) * 0.05, 1e-3)
+
+    forward = _world_axis_unit(placement_metadata, "forward_axis", 1)
+    center = [head_pt[i] + EYE_LEVEL_RATIO * (head_tail[i] - head_pt[i]) for i in range(3)]
+    center = _offset_point(center, forward, EYE_FORWARD_RATIO * head_len)
+
+    side_sign = 1 if target_name.endswith("_Left") else -1
+    side = _world_axis_unit(placement_metadata, "side_axis", side_sign)
+    eye_head = _offset_point(center, side, EYE_SEP_RATIO * head_len)
+    eye_tail = _offset_point(eye_head, forward, EYE_LEN_RATIO * head_len)
+    return _ensure_non_zero_geometry(eye_head, eye_tail, placement_metadata), "eye_anchored", None
+
+
 def _resolve_created_target_geometry(
     target_name: str,
     semantic_mapping: dict,
@@ -551,6 +582,16 @@ def _normalize(vector: Sequence[float]) -> List[float]:
 
 def _offset_point(point: Sequence[float], direction: Sequence[float], distance: float) -> List[float]:
     return [float(point[index] + (direction[index] * distance)) for index in range(3)]
+
+
+def _world_axis_unit(placement_metadata: dict, axis_key: str, sign: int) -> List[float]:
+    """Unit vector along a placement axis in world coords. `sign` selects the
+    direction relative to the axis's own world sign (e.g. side_axis with sign=+1
+    is the Left direction, sign=-1 the Right)."""
+    axis = placement_metadata[axis_key]
+    vector = [0.0, 0.0, 0.0]
+    vector[int(axis["index"])] = float(sign) * float(axis["sign"])
+    return vector
 
 
 def _ensure_non_zero_geometry(head: Sequence[float], tail: Sequence[float], placement_metadata: dict) -> dict:

--- a/src/asam_human_builder/geometry_resolution.py
+++ b/src/asam_human_builder/geometry_resolution.py
@@ -62,7 +62,9 @@ DEFAULT_LENGTH_RATIOS = {
 }
 
 # Eye placement ratios (fractions of Head bone length), issue #64.
-EYE_LEVEL_RATIO = 0.5     # fraction along the Head bone (base->crown) for eye level
+EYE_DROP_FROM_CROWN = 0.22  # eye level as a drop below the crown (Head.tail); the head
+                            # bone's base often sits at the neck, so a base-relative
+                            # midpoint lands on the lower face (#64). Anchor from the crown.
 EYE_FORWARD_RATIO = 0.5   # forward offset onto the face
 EYE_SEP_RATIO = 0.3       # lateral half-separation between the two eyes
 EYE_LEN_RATIO = 0.15      # eye bone length (forward/gaze)
@@ -349,7 +351,7 @@ def _resolve_eye_geometry(
         head_len = max(float(placement_metadata.get("bbox_height", 0.0)) * 0.05, 1e-3)
 
     forward = _world_axis_unit(placement_metadata, "forward_axis", 1)
-    center = [head_pt[i] + EYE_LEVEL_RATIO * (head_tail[i] - head_pt[i]) for i in range(3)]
+    center = [head_tail[i] - EYE_DROP_FROM_CROWN * (head_tail[i] - head_pt[i]) for i in range(3)]
     center = _offset_point(center, forward, EYE_FORWARD_RATIO * head_len)
 
     side_sign = 1 if target_name.endswith("_Left") else -1

--- a/src/asam_human_builder/geometry_resolution.py
+++ b/src/asam_human_builder/geometry_resolution.py
@@ -399,6 +399,22 @@ def _resolve_created_target_geometry(
     children_map: Dict[str, List[str]],
     resolved_geometry: Dict[str, dict],
 ) -> Tuple[dict, str, Optional[str]]:
+    family = _family_label(target_name)
+    if family in {"Eye", "Full_Fingers", "Full_Thumb"}:
+        parent_name = bone_parents.get(target_name)
+        parent_geometry = (
+            _get_reference_geometry(
+                parent_name, semantic_mapping, root_resolution,
+                source_bones, resolved_geometry, placement_metadata,
+            )
+            if parent_name
+            else None
+        )
+        if parent_geometry is not None:
+            if family == "Eye":
+                return _resolve_eye_geometry(target_name, parent_geometry, placement_metadata)
+            return _resolve_finger_geometry(target_name, parent_geometry, placement_metadata)
+
     opposite_target = _opposite_target_name(target_name)
     opposite_geometry = None
     if opposite_target is not None:

--- a/src/asam_human_builder/geometry_resolution.py
+++ b/src/asam_human_builder/geometry_resolution.py
@@ -69,12 +69,6 @@ EYE_FORWARD_RATIO = 0.5   # forward offset onto the face
 EYE_SEP_RATIO = 0.3       # lateral half-separation between the two eyes
 EYE_LEN_RATIO = 0.15      # eye bone length (forward/gaze)
 
-# Finger/thumb placement ratios (fractions of Hand bone length), issue #64.
-FINGERS_LEN_RATIO = 1.4      # finger bone length from the wrist (covers hand + fingers)
-THUMB_LEN_RATIO = 0.6        # thumb bone length from the wrist (shorter)
-THUMB_FORWARD_DIVERGE = 0.6  # thumb divergence toward the palm (forward axis)
-THUMB_DOWN_DIVERGE = 0.4     # thumb divergence downward (away from up axis)
-
 
 def _resolve_target_geometry(
     target_name: str,
@@ -367,27 +361,20 @@ def _resolve_finger_geometry(
     placement_metadata: dict,
 ) -> Tuple[dict, str, None]:
     """Anchor synthesized fingers/thumb at the wrist (carpal beginning, issue #64).
-    Full_Fingers continues the hand direction to fingertip length; Full_Thumb
-    diverges toward the palm and is shorter. Parent is the Hand; X-forward/
-    Z-sideward orientation is applied by the roll pass."""
+
+    Both `Full_Fingers` and `Full_Thumb` originate at the wrist and point along the
+    Hand bone. The builder's `_orient_terminal_extremities` pass owns the final tail
+    direction and length for terminal bones, so this resolver only needs to establish
+    the wrist head anchor with a non-degenerate tail — any tail divergence/length set
+    here would be discarded. Parent is the Hand; X-forward/Z-sideward orientation is
+    applied by the roll pass."""
     wrist = [float(v) for v in hand_geometry["head"]]
     hand_end = [float(v) for v in hand_geometry["tail"]]
     hand_len = _distance(wrist, hand_end)
     if hand_len <= 1e-6:
         hand_len = max(float(placement_metadata.get("bbox_height", 0.0)) * 0.05, 1e-3)
     hand_dir = _normalize([hand_end[i] - wrist[i] for i in range(3)])
-
-    if _family_label(target_name) == "Full_Fingers":
-        tail = _offset_point(wrist, hand_dir, FINGERS_LEN_RATIO * hand_len)
-        return _ensure_non_zero_geometry(wrist, tail, placement_metadata), "finger_anchored", None
-
-    forward = _world_axis_unit(placement_metadata, "forward_axis", 1)
-    down = _world_axis_unit(placement_metadata, "up_axis", -1)
-    thumb_dir = _normalize([
-        hand_dir[i] + (THUMB_FORWARD_DIVERGE * forward[i]) + (THUMB_DOWN_DIVERGE * down[i])
-        for i in range(3)
-    ])
-    tail = _offset_point(wrist, thumb_dir, THUMB_LEN_RATIO * hand_len)
+    tail = _offset_point(wrist, hand_dir, hand_len)
     return _ensure_non_zero_geometry(wrist, tail, placement_metadata), "finger_anchored", None
 
 

--- a/src/asam_human_builder/geometry_resolution.py
+++ b/src/asam_human_builder/geometry_resolution.py
@@ -67,6 +67,12 @@ EYE_FORWARD_RATIO = 0.5   # forward offset onto the face
 EYE_SEP_RATIO = 0.3       # lateral half-separation between the two eyes
 EYE_LEN_RATIO = 0.15      # eye bone length (forward/gaze)
 
+# Finger/thumb placement ratios (fractions of Hand bone length), issue #64.
+FINGERS_LEN_RATIO = 1.4      # finger bone length from the wrist (covers hand + fingers)
+THUMB_LEN_RATIO = 0.6        # thumb bone length from the wrist (shorter)
+THUMB_FORWARD_DIVERGE = 0.6  # thumb divergence toward the palm (forward axis)
+THUMB_DOWN_DIVERGE = 0.4     # thumb divergence downward (away from up axis)
+
 
 def _resolve_target_geometry(
     target_name: str,
@@ -351,6 +357,36 @@ def _resolve_eye_geometry(
     eye_head = _offset_point(center, side, EYE_SEP_RATIO * head_len)
     eye_tail = _offset_point(eye_head, forward, EYE_LEN_RATIO * head_len)
     return _ensure_non_zero_geometry(eye_head, eye_tail, placement_metadata), "eye_anchored", None
+
+
+def _resolve_finger_geometry(
+    target_name: str,
+    hand_geometry: dict,
+    placement_metadata: dict,
+) -> Tuple[dict, str, None]:
+    """Anchor synthesized fingers/thumb at the wrist (carpal beginning, issue #64).
+    Full_Fingers continues the hand direction to fingertip length; Full_Thumb
+    diverges toward the palm and is shorter. Parent is the Hand; X-forward/
+    Z-sideward orientation is applied by the roll pass."""
+    wrist = [float(v) for v in hand_geometry["head"]]
+    hand_end = [float(v) for v in hand_geometry["tail"]]
+    hand_len = _distance(wrist, hand_end)
+    if hand_len <= 1e-6:
+        hand_len = max(float(placement_metadata.get("bbox_height", 0.0)) * 0.05, 1e-3)
+    hand_dir = _normalize([hand_end[i] - wrist[i] for i in range(3)])
+
+    if _family_label(target_name) == "Full_Fingers":
+        tail = _offset_point(wrist, hand_dir, FINGERS_LEN_RATIO * hand_len)
+        return _ensure_non_zero_geometry(wrist, tail, placement_metadata), "finger_anchored", None
+
+    forward = _world_axis_unit(placement_metadata, "forward_axis", 1)
+    down = _world_axis_unit(placement_metadata, "up_axis", -1)
+    thumb_dir = _normalize([
+        hand_dir[i] + (THUMB_FORWARD_DIVERGE * forward[i]) + (THUMB_DOWN_DIVERGE * down[i])
+        for i in range(3)
+    ])
+    tail = _offset_point(wrist, thumb_dir, THUMB_LEN_RATIO * hand_len)
+    return _ensure_non_zero_geometry(wrist, tail, placement_metadata), "finger_anchored", None
 
 
 def _resolve_created_target_geometry(

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -3137,6 +3137,20 @@ class EyePlacementTests(unittest.TestCase):
         self.assertEqual((lsrc, lbone), ("eye_anchored", None))
         self.assertEqual((rsrc, rbone), ("eye_anchored", None))
 
+    def test_eyes_sit_in_upper_head_near_crown(self):
+        # Regression for the "eyes at mouth level" bug (#64): a Head bone whose
+        # base sits at the neck means a mid-bone eye level lands on the lower face.
+        # Eyes must anchor near the crown (Head.tail), in the upper part of the head.
+        from asam_human_builder.geometry_resolution import _resolve_eye_geometry
+        pm = _placement_metadata()
+        head = self._head()  # base z=1.5 (neck), crown z=1.7
+        base_z, crown_z = head["head"][2], head["tail"][2]
+        upper_threshold = base_z + 0.65 * (crown_z - base_z)  # 1.63
+        left, _, _ = _resolve_eye_geometry("Eye_Left", head, pm)
+        # Eye sits in the upper head, but still below the crown (not floating above).
+        self.assertGreater(left["head"][2], upper_threshold)
+        self.assertLessEqual(left["head"][2], crown_z)
+
 
 class SingleSpineSplitPipelineIntegrationTests(unittest.TestCase):
     """End-to-end on-disk seam for the single-spine geometric split (#56).

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -3219,8 +3219,9 @@ class SingleSpineSplitPipelineIntegrationTests(unittest.TestCase):
 
 
 class FingerPlacementTests(unittest.TestCase):
-    """Synthesized fingers/thumb anchor at the wrist (carpal beginning): fingers
-    continue the hand direction to fingertip length; thumb diverges, shorter."""
+    """Synthesized fingers/thumb anchor at the wrist (carpal beginning) and point
+    along the Hand bone. The builder's terminal-orientation pass owns the final tail
+    direction/length, so the resolver only establishes the wrist head anchor."""
 
     def _hand(self, side_sign=1):
         wrist = [0.5, 0.1 * side_sign, 1.2]
@@ -3228,25 +3229,26 @@ class FingerPlacementTests(unittest.TestCase):
         return {"name": "Hand", "parent": "Lower_Arm",
                 "head": wrist, "tail": end, "length": _distance_for_test(wrist, end)}
 
-    def test_fingers_anchor_at_wrist_and_extend_along_hand(self):
+    def test_fingers_anchor_at_wrist_along_hand(self):
         from asam_human_builder.geometry_resolution import _resolve_finger_geometry
         pm = _placement_metadata()
         hand = self._hand()
         fingers, fsrc, fbone = _resolve_finger_geometry("Full_Fingers_Left", hand, pm)
         self.assertEqual(fingers["head"], [float(v) for v in hand["head"]])  # wrist anchor
-        self.assertGreater(fingers["tail"][1], hand["tail"][1])              # extends past hand end (+y)
-        self.assertGreater(fingers["length"], hand["length"])
+        self.assertGreater(fingers["tail"][1], hand["head"][1])              # points along hand (+y)
+        self.assertGreater(fingers["length"], 0.0)                           # non-degenerate
         self.assertEqual((fsrc, fbone), ("finger_anchored", None))
 
-    def test_thumb_diverges_from_fingers_and_is_shorter(self):
+    def test_thumb_and_fingers_share_wrist_anchor(self):
+        # Divergence and length are set later by _orient_terminal_extremities, so the
+        # resolver produces the same wrist-anchored placeholder for thumb and fingers.
         from asam_human_builder.geometry_resolution import _resolve_finger_geometry
         pm = _placement_metadata()
         hand = self._hand()
         fingers, _, _ = _resolve_finger_geometry("Full_Fingers_Left", hand, pm)
         thumb, tsrc, tbone = _resolve_finger_geometry("Full_Thumb_Left", hand, pm)
-        self.assertEqual(thumb["head"], [float(v) for v in hand["head"]])    # same wrist anchor
-        self.assertTrue(thumb["tail"][0] != fingers["tail"][0] or thumb["tail"][2] != fingers["tail"][2])  # diverges
-        self.assertLess(thumb["length"], fingers["length"])                  # shorter
+        self.assertEqual(thumb["head"], [float(v) for v in hand["head"]])    # wrist anchor
+        self.assertEqual(thumb["head"], fingers["head"])                     # same origin as fingers
         self.assertEqual((tsrc, tbone), ("finger_anchored", None))
 
     def test_sides_derive_from_their_own_hand_independently(self):

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -3244,5 +3244,79 @@ class FingerPlacementTests(unittest.TestCase):
         self.assertLess(right["tail"][1], 0.0)      # right follows -y hand
 
 
+class EyeFingerDispatchTests(unittest.TestCase):
+    """The created-target resolver routes Eye_* to the Head anchor and
+    Full_*_* to the same-side Hand anchor, and falls through when the parent
+    is unavailable."""
+
+    def _bone_parents(self):
+        return {"Eye_Left": "Head", "Eye_Right": "Head",
+                "Full_Fingers_Left": "Hand_Left", "Full_Thumb_Left": "Hand_Left",
+                "Full_Fingers_Right": "Hand_Right", "Full_Thumb_Right": "Hand_Right"}
+
+    def _semantic(self, *targets):
+        # Include both the requested targets plus their opposites (for mirroring logic)
+        all_targets = set(targets)
+        for target in targets:
+            opposite = None
+            if target.endswith("_Left"):
+                opposite = target[:-5] + "_Right"
+            elif target.endswith("_Right"):
+                opposite = target[:-6] + "_Left"
+            if opposite:
+                all_targets.add(opposite)
+        return {t: {"action": "create_in_builder", "source_bone": None, "notes": []} for t in all_targets}
+
+    def test_eye_routes_to_head_anchor(self):
+        from asam_human_builder.geometry_resolution import _resolve_created_target_geometry
+        pm = _placement_metadata()
+        resolved = {"Head": {"name": "Head", "parent": "Neck",
+                             "head": [0.0, 0.0, 1.5], "tail": [0.0, 0.0, 1.7], "length": 0.2}}
+        geometry, source, bone = _resolve_created_target_geometry(
+            "Eye_Left", self._semantic("Eye_Left"), {}, {}, pm,
+            self._bone_parents(), {}, resolved,
+        )
+        self.assertEqual(source, "eye_anchored")
+        self.assertNotEqual(geometry["head"], resolved["Head"]["tail"])  # not chin-collapsed
+
+    def test_fingers_route_to_same_side_hand(self):
+        from asam_human_builder.geometry_resolution import _resolve_created_target_geometry
+        pm = _placement_metadata()
+        resolved = {"Hand_Left": {"name": "Hand_Left", "parent": "Lower_Arm_Left",
+                                  "head": [0.5, 0.1, 1.2], "tail": [0.5, 0.3, 1.2], "length": 0.2}}
+        geometry, source, bone = _resolve_created_target_geometry(
+            "Full_Fingers_Left", self._semantic("Full_Fingers_Left"), {}, {}, pm,
+            self._bone_parents(), {}, resolved,
+        )
+        self.assertEqual(source, "finger_anchored")
+        self.assertEqual(geometry["head"], [0.5, 0.1, 1.2])  # wrist anchor
+
+    def test_falls_through_when_parent_unavailable(self):
+        from asam_human_builder.geometry_resolution import _resolve_created_target_geometry
+        pm = _placement_metadata()
+        # Head present in semantic_mapping (as always in production) but unresolved
+        # (create_in_builder, no source) and absent from resolved_geometry -> the
+        # eye anchor cannot resolve a parent and must fall through to the generic path.
+        semantic = self._semantic("Eye_Left", "Head")
+        geometry, source, bone = _resolve_created_target_geometry(
+            "Eye_Left", semantic, {}, {}, pm,
+            self._bone_parents(), {}, {},
+        )
+        self.assertNotEqual(source, "eye_anchored")  # generic fallback ran instead
+        self.assertIsNotNone(geometry)               # still produced a bone, no crash
+
+    def test_mapped_eye_is_not_anchored(self):
+        from asam_human_builder.geometry_resolution import _resolve_target_geometry
+        pm = _placement_metadata()
+        semantic = {"Eye_Left": {"action": "direct_map", "source_bone": "L_eye", "notes": []}}
+        source_bones = {"L_eye": {"name": "L_eye", "parent": "Head",
+                                  "head": [0.3, 0.1, 1.6], "tail": [0.35, 0.1, 1.6], "length": 0.05}}
+        geometry, source, bone = _resolve_target_geometry(
+            "Eye_Left", semantic, {}, source_bones, pm, {"Eye_Left": "Head"}, {}, {}, [],
+        )
+        self.assertEqual(source, "source_bone")   # direct map, not eye_anchored
+        self.assertEqual(bone, "L_eye")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -3102,6 +3102,38 @@ def _write_single_spine_asset_on_disk(asset_name: str = "single_spine_integratio
     return asset_dir
 
 
+class EyePlacementTests(unittest.TestCase):
+    """Synthesized eyes anchor to the Head bone: two distinct bones on the
+    front-upper face, symmetric about the head, never collapsed to Head.tail."""
+
+    def _head(self):
+        return {"name": "Head", "parent": "Neck",
+                "head": [0.0, 0.0, 1.5], "tail": [0.0, 0.0, 1.7], "length": 0.2}
+
+    def test_eyes_are_distinct_front_upper_and_symmetric(self):
+        from asam_human_builder.geometry_resolution import _resolve_eye_geometry
+        pm = _placement_metadata()  # forward=+x, side=+y, up=+z
+        head = self._head()
+        left, lsrc, lbone = _resolve_eye_geometry("Eye_Left", head, pm)
+        right, rsrc, rbone = _resolve_eye_geometry("Eye_Right", head, pm)
+
+        self.assertGreater(left["head"][1], 0.0)    # Left -> +side (+y)
+        self.assertLess(right["head"][1], 0.0)      # Right -> -side (-y)
+        self.assertAlmostEqual(left["head"][1], -right["head"][1], places=6)  # symmetric
+
+        self.assertGreater(left["head"][0], 0.0)                 # in front (forward +x)
+        self.assertGreater(left["head"][2], head["head"][2])     # above head base
+
+        self.assertNotEqual(left["head"], head["tail"])          # NOT chin-collapsed
+        self.assertNotEqual(right["head"], head["tail"])
+
+        self.assertGreater(left["tail"][0], left["head"][0])     # points forward (gaze)
+        self.assertGreater(left["length"], 0.0)
+
+        self.assertEqual((lsrc, lbone), ("eye_anchored", None))
+        self.assertEqual((rsrc, rbone), ("eye_anchored", None))
+
+
 class SingleSpineSplitPipelineIntegrationTests(unittest.TestCase):
     """End-to-end on-disk seam for the single-spine geometric split (#56).
 

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -213,6 +213,10 @@ def _assert_vec_almost_equal(test_case: unittest.TestCase, actual, expected, pla
         test_case.assertAlmostEqual(actual_value, expected_value, places=places)
 
 
+def _distance_for_test(a, b):
+    return sum((b[i] - a[i]) ** 2 for i in range(3)) ** 0.5
+
+
 class _FakeProps:
     def __init__(self):
         self._props = {}
@@ -3198,6 +3202,46 @@ class SingleSpineSplitPipelineIntegrationTests(unittest.TestCase):
         self.assertEqual(renames.get("Spine"), "Lower_Spine")
         self.assertNotIn("Upper_Spine", renames.values())
         self.assertEqual(remap["name_collisions"], [])
+
+
+class FingerPlacementTests(unittest.TestCase):
+    """Synthesized fingers/thumb anchor at the wrist (carpal beginning): fingers
+    continue the hand direction to fingertip length; thumb diverges, shorter."""
+
+    def _hand(self, side_sign=1):
+        wrist = [0.5, 0.1 * side_sign, 1.2]
+        end = [0.5, 0.3 * side_sign, 1.2]
+        return {"name": "Hand", "parent": "Lower_Arm",
+                "head": wrist, "tail": end, "length": _distance_for_test(wrist, end)}
+
+    def test_fingers_anchor_at_wrist_and_extend_along_hand(self):
+        from asam_human_builder.geometry_resolution import _resolve_finger_geometry
+        pm = _placement_metadata()
+        hand = self._hand()
+        fingers, fsrc, fbone = _resolve_finger_geometry("Full_Fingers_Left", hand, pm)
+        self.assertEqual(fingers["head"], [float(v) for v in hand["head"]])  # wrist anchor
+        self.assertGreater(fingers["tail"][1], hand["tail"][1])              # extends past hand end (+y)
+        self.assertGreater(fingers["length"], hand["length"])
+        self.assertEqual((fsrc, fbone), ("finger_anchored", None))
+
+    def test_thumb_diverges_from_fingers_and_is_shorter(self):
+        from asam_human_builder.geometry_resolution import _resolve_finger_geometry
+        pm = _placement_metadata()
+        hand = self._hand()
+        fingers, _, _ = _resolve_finger_geometry("Full_Fingers_Left", hand, pm)
+        thumb, tsrc, tbone = _resolve_finger_geometry("Full_Thumb_Left", hand, pm)
+        self.assertEqual(thumb["head"], [float(v) for v in hand["head"]])    # same wrist anchor
+        self.assertTrue(thumb["tail"][0] != fingers["tail"][0] or thumb["tail"][2] != fingers["tail"][2])  # diverges
+        self.assertLess(thumb["length"], fingers["length"])                  # shorter
+        self.assertEqual((tsrc, tbone), ("finger_anchored", None))
+
+    def test_sides_derive_from_their_own_hand_independently(self):
+        from asam_human_builder.geometry_resolution import _resolve_finger_geometry
+        pm = _placement_metadata()
+        left, _, _ = _resolve_finger_geometry("Full_Fingers_Left", self._hand(1), pm)
+        right, _, _ = _resolve_finger_geometry("Full_Fingers_Right", self._hand(-1), pm)
+        self.assertGreater(left["tail"][1], 0.0)    # left follows +y hand
+        self.assertLess(right["tail"][1], 0.0)      # right follows -y hand
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #64.

## Summary

When an off-the-shelf rig has **no eye/finger bones**, the builder used to synthesize `Eye_*` and `Full_Fingers_/Full_Thumb_*` via a generic fallback that collapsed both eyes onto the chin and overlapped the fingers on the hand. This anchors them to the parent bone instead, in the pure-Python placement layer.

- **Eyes** (`_resolve_eye_geometry`): anchored to the `Head` bone — eye level a small drop **below the crown** (`Head.tail`, robust to the bone's base sitting at the neck), offset forward onto the face, split laterally so `Eye_Left`/`Eye_Right` are distinct. Bone points forward (gaze); X resolves up via the #55 roll pass.
- **Fingers/thumb** (`_resolve_finger_geometry`): anchored at the wrist (carpal beginning, per ASAM "middle finger position and length"), `Full_Fingers` continuing the hand direction, `Full_Thumb` from the wrist.
- **Dispatch**: routed from `_resolve_created_target_geometry` by bone family, only for synthesized targets (no source bone) whose parent (`Head` / same-side `Hand`) is resolved; otherwise falls through to the existing fallback. A rig that *has* real eye/finger bones still direct-maps them, untouched.

`Full_Fingers`/`Full_Thumb` are leaf children of `Hand`, `Eye_*` children of `Head` — ASAM hierarchy preserved. The synthesized geometry-source tags are excluded from `SOURCE_NAMED_GEOMETRY_SOURCES` (no vertex group claimed).

## Test Plan

- [x] `python -m unittest discover tests` green (316 tests)
- [x] Eyes: distinct, symmetric, in front of and in the **upper** part of the Head (regression guard vs the chin/mouth collapse); fall through cleanly when Head unavailable; mapped eyes untouched
- [x] Fingers/thumb: wrist-anchored, per-side independent
- [x] Verified on the real `LowPolyCharacter4` data: eyes moved from mouth level (z≈1.80) to upper face (z≈1.89)

## Known follow-ups (separate issues)
- The terminal-orientation pass overrides finger/thumb **tail** length+direction with a default, so the thumb's palm-divergence constants are currently inert (head/wrist anchor survives) — minor cleanup.
- Collapsing a **fully-fingered** hand into these ASAM bones is tracked in #67 (the inverse problem).