### PR TITLE
Crowd build success UI metrics (#69) + .glb export (#72)

### DIFF
--- a/addon/operators.py
+++ b/addon/operators.py
@@ -94,7 +94,12 @@ class OJ_OT_build(bpy.types.Operator):
         asset_dir = Path(settings.asset_dir)
         context.window.cursor_set('WAIT')
         try:
-            report = run_build(asset_dir, bpy, packaging_mode=settings.packaging_mode)
+            report = run_build(
+                asset_dir, 
+                bpy, 
+                packaging_mode=settings.packaging_mode,
+                export_gltf=settings.export_gltf
+            )
         except Exception as exc:  # surface as an operator error, never crash
             self.report({'ERROR'}, "Build failed: {0}".format(exc))
             return {'CANCELLED'}

--- a/addon/operators.py
+++ b/addon/operators.py
@@ -103,6 +103,17 @@ class OJ_OT_build(bpy.types.Operator):
         report_path = asset_dir / "builder_report.json"
         self.report({'INFO'}, success_message(report, report_path))
         settings.built = True
+
+        if "characters" in report:
+            settings.build_succeeded = len(report.get("characters", []))
+            failed = report.get("failed_characters", [])
+            settings.build_failed = len(failed)
+            settings.failed_characters_csv = ", ".join(f.get("character_id", "") for f in failed)
+        else:
+            settings.build_succeeded = 1 if report.get("built_core_targets") else 0
+            settings.build_failed = 0
+            settings.failed_characters_csv = ""
+
         return {'FINISHED'}
 
 

--- a/addon/state.py
+++ b/addon/state.py
@@ -33,3 +33,8 @@ class OJSettings(bpy.types.PropertyGroup):
         ],
         default="inplace_export",
     )
+    export_gltf: bpy.props.BoolProperty(
+        default=False, 
+        name="Export glTF / .glb",
+        description="Wrap and export the generated ASAM human to .glb format"
+    )

--- a/addon/state.py
+++ b/addon/state.py
@@ -17,6 +17,9 @@ class OJSettings(bpy.types.PropertyGroup):
     character_ids_csv: bpy.props.StringProperty(default="")
     is_crowd: bpy.props.BoolProperty(default=False)
     character_count: bpy.props.IntProperty(default=0)
+    build_succeeded: bpy.props.IntProperty(default=0)
+    build_failed: bpy.props.IntProperty(default=0)
+    failed_characters_csv: bpy.props.StringProperty(default="")
     packaging_mode: bpy.props.EnumProperty(
         name="Output",
         description="How to package the generated ASAM human(s)",

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -70,6 +70,7 @@ class OJ_PT_panel(bpy.types.Panel):
                     )
 
             layout.prop(s, "packaging_mode")
+            layout.prop(s, "export_gltf")
             build_row = layout.row()
             build_row.enabled = s.has_plan and not s.built
             build_row.operator("open_jaywalker.build", icon='MOD_ARMATURE')

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -74,6 +74,26 @@ class OJ_PT_panel(bpy.types.Panel):
             build_row.enabled = s.has_plan and not s.built
             build_row.operator("open_jaywalker.build", icon='MOD_ARMATURE')
 
+        if s.built:
+            layout.separator()
+            res_box = layout.box()
+            res_box.label(text="Build Results", icon='INFO')
+            res_col = res_box.column(align=True)
+            if s.is_crowd:
+                res_col.label(text="Succeeded: {0}".format(s.build_succeeded), icon='CHECKMARK')
+                if s.build_failed > 0:
+                    res_col.label(text="Failed: {0}".format(s.build_failed), icon='ERROR')
+                    det = res_box.box()
+                    det.label(text="Failed characters:")
+                    for cid in s.failed_characters_csv.split(", "):
+                        if cid:
+                            det.label(text="   - {0}".format(cid))
+            else:
+                if s.build_succeeded > 0:
+                    res_col.label(text="Successfully built character.", icon='CHECKMARK')
+                else:
+                    res_col.label(text="Build failed.", icon='ERROR')
+
         if s.asset_dir:
             layout.separator()
             layout.label(text="Output:")

--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -775,3 +775,37 @@ def export_generated_blend(bpy_module, wrapper_collection_name: str, filepath: s
         os.makedirs(directory, exist_ok=True)
     bpy_module.data.libraries.write(filepath, {wrapper}, fake_user=True)
     return filepath
+
+
+def export_generated_gltf(bpy_module, wrapper_collection_name: str, filepath: str) -> str:
+    """Write ONLY the generated wrapper collection (and what it references) to a .glb.
+
+    Raises ValueError if the wrapper is absent or not a generated collection.
+    """
+    wrapper = bpy_module.data.collections.get(wrapper_collection_name)
+    if wrapper is None or not bool(wrapper.get(GENERATED_MARKER_KEY)):
+        raise ValueError(
+            "Refusing to export '{0}': not a generated wrapper collection".format(
+                wrapper_collection_name
+            )
+        )
+    import os
+    directory = os.path.dirname(filepath)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+        
+    try:
+        bpy_module.ops.object.mode_set(mode="OBJECT")
+    except RuntimeError:
+        pass
+    bpy_module.ops.object.select_all(action='DESELECT')
+    
+    for obj in wrapper.all_objects:
+        obj.select_set(True)
+        
+    bpy_module.ops.export_scene.gltf(
+        filepath=filepath,
+        use_selection=True,
+        export_format='GLB',
+    )
+    return filepath

--- a/src/asam_human_builder/build_runner.py
+++ b/src/asam_human_builder/build_runner.py
@@ -21,6 +21,7 @@ from asam_human_builder.blender_builder import (
     build_armature_in_blender,
     build_crowd_in_blender,
     export_generated_blend,
+    export_generated_gltf,
     purge_previous_generated_artifacts,
 )
 
@@ -32,7 +33,7 @@ PACKAGING_SEPARATE_ONLY = "separate_only"
 PACKAGING_MODES = (PACKAGING_INPLACE_EXPORT, PACKAGING_INPLACE_ONLY, PACKAGING_SEPARATE_ONLY)
 
 
-def run_build(asset_dir, bpy, packaging_mode=PACKAGING_INPLACE_EXPORT) -> dict:
+def run_build(asset_dir, bpy, packaging_mode=PACKAGING_INPLACE_EXPORT, export_gltf=False) -> dict:
     """Resolve specs for asset_dir and build them (single or crowd).
 
     packaging_mode controls post-build export:
@@ -71,13 +72,13 @@ def run_build(asset_dir, bpy, packaging_mode=PACKAGING_INPLACE_EXPORT) -> dict:
         print_builder_summary(report, report_path)
         wrapper_name = build_spec["generated_collection_name"]
 
-    _export_if_requested(asset_dir, resolved["asset_name"], wrapper_name, bpy, packaging_mode, report)
+    _export_if_requested(asset_dir, resolved["asset_name"], wrapper_name, bpy, packaging_mode, export_gltf, report)
 
     print(success_message(report, report_path))
     return report
 
 
-def _export_if_requested(asset_dir, asset_name, wrapper_name, bpy, packaging_mode, report):
+def _export_if_requested(asset_dir, asset_name, wrapper_name, bpy, packaging_mode, export_gltf, report):
     """Record packaging outcome on the report and export when requested.
 
     Modes:
@@ -99,6 +100,16 @@ def _export_if_requested(asset_dir, asset_name, wrapper_name, bpy, packaging_mod
         report["exported_blend_path"] = export_generated_blend(bpy, wrapper_name, out_path)
     except Exception as exc:  # never abort the already-completed in-place build
         report["export_error"] = str(exc)
-        return
+        
+    report["export_gltf"] = export_gltf
+    report["exported_gltf_path"] = None
+    report["export_gltf_error"] = None
+    if export_gltf:
+        out_gltf = str(Path(asset_dir) / "{0}_asam.glb".format(asset_name))
+        try:
+            report["exported_gltf_path"] = export_generated_gltf(bpy, wrapper_name, out_gltf)
+        except Exception as exc:
+            report["export_gltf_error"] = str(exc)
+            
     if packaging_mode == PACKAGING_SEPARATE_ONLY:
         purge_previous_generated_artifacts(bpy)


### PR DESCRIPTION
Closes #69. Closes #72.

Two small, independent add-on features that were developed alongside the #64 work and are split out here for clean review.

## #69 — Crowd build success UI metrics
Surfaces per-build success metrics for crowd assets in the add-on UI (`addon/operators.py`, `addon/state.py`, `addon/ui.py`).

## #72 — .glb export
Adds `.glb` export of the generated ASAM result (`addon/operators.py`, `addon/state.py`, `addon/ui.py`, `src/asam_human_builder/blender_builder.py`, `src/asam_human_builder/build_runner.py`).

## Test Plan
- [x] `python -m unittest discover tests` green (307 tests)

> Note: these commits were authored on the #64 branch during a shared session; cherry-picked onto a clean branch off main so #64 stays isolated in #77.