### PR TITLE
feat(builder): surface warnings for synthesized inert bones

### DIFF
--- a/addon/operators.py
+++ b/addon/operators.py
@@ -24,6 +24,8 @@ class OJ_OT_run_pipeline(bpy.types.Operator):
         settings = context.scene.open_jaywalker
         settings.has_plan = False
         settings.built = False
+        settings.synthesized_bones_csv = ""
+        settings.synthesized_bones_by_character_csv = ""
 
         prefs = _addon_prefs(context)
         if prefs.output_dir:
@@ -114,10 +116,31 @@ class OJ_OT_build(bpy.types.Operator):
             failed = report.get("failed_characters", [])
             settings.build_failed = len(failed)
             settings.failed_characters_csv = ", ".join(f.get("character_id", "") for f in failed)
+            
+            synth_list = []
+            for char_report in report.get("characters", []):
+                heuristics = char_report.get("targets_created_heuristically", [])
+                if heuristics:
+                    synth_list.append("{0} ({1})".format(
+                        char_report.get("character_id"),
+                        ", ".join(heuristics)
+                    ))
+            settings.synthesized_bones_by_character_csv = " | ".join(synth_list)
+            if synth_list:
+                self.report({'WARNING'}, "Synthesized inert bones added for compliance: {0}".format(
+                    ", ".join(synth_list)
+                ))
         else:
             settings.build_succeeded = 1 if report.get("built_core_targets") else 0
             settings.build_failed = 0
             settings.failed_characters_csv = ""
+            
+            heuristics = report.get("targets_created_heuristically", [])
+            settings.synthesized_bones_csv = ", ".join(heuristics)
+            if heuristics:
+                self.report({'WARNING'}, "Synthesized inert bones added for compliance: {0}".format(
+                    ", ".join(heuristics)
+                ))
 
         return {'FINISHED'}
 
@@ -143,6 +166,9 @@ class OJ_OT_clean(bpy.types.Operator):
 
     def execute(self, context):
         removed = purge_previous_generated_artifacts(bpy)
-        context.scene.open_jaywalker.built = False
+        s = context.scene.open_jaywalker
+        s.built = False
+        s.synthesized_bones_csv = ""
+        s.synthesized_bones_by_character_csv = ""
         self.report({'INFO'}, "Removed {0} generated object(s)/collection(s).".format(removed))
         return {'FINISHED'}

--- a/addon/state.py
+++ b/addon/state.py
@@ -20,6 +20,8 @@ class OJSettings(bpy.types.PropertyGroup):
     build_succeeded: bpy.props.IntProperty(default=0)
     build_failed: bpy.props.IntProperty(default=0)
     failed_characters_csv: bpy.props.StringProperty(default="")
+    synthesized_bones_csv: bpy.props.StringProperty(default="")
+    synthesized_bones_by_character_csv: bpy.props.StringProperty(default="")
     packaging_mode: bpy.props.EnumProperty(
         name="Output",
         description="How to package the generated ASAM human(s)",

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -89,9 +89,23 @@ class OJ_PT_panel(bpy.types.Panel):
                     for cid in s.failed_characters_csv.split(", "):
                         if cid:
                             det.label(text="   - {0}".format(cid))
+                if s.synthesized_bones_by_character_csv:
+                    warn_box = res_box.box()
+                    warn_box.alert = True
+                    warn_box.label(text="Synthesized Inert Bones (unbound):", icon='WARNING')
+                    for line in s.synthesized_bones_by_character_csv.split(" | "):
+                        if line:
+                            warn_box.label(text="   {0}".format(line))
             else:
                 if s.build_succeeded > 0:
                     res_col.label(text="Successfully built character.", icon='CHECKMARK')
+                    if s.synthesized_bones_csv:
+                        warn_box = res_box.box()
+                        warn_box.alert = True
+                        warn_box.label(text="Synthesized Inert Bones (unbound):", icon='WARNING')
+                        for name in s.synthesized_bones_csv.split(", "):
+                            if name:
+                                warn_box.label(text="   - {0}".format(name))
                 else:
                     res_col.label(text="Build failed.", icon='ERROR')
 

--- a/src/asam_human_builder/build_runner.py
+++ b/src/asam_human_builder/build_runner.py
@@ -74,6 +74,21 @@ def run_build(asset_dir, bpy, packaging_mode=PACKAGING_INPLACE_EXPORT, export_gl
 
     _export_if_requested(asset_dir, resolved["asset_name"], wrapper_name, bpy, packaging_mode, export_gltf, report)
 
+    if resolved["crowd"]:
+        for char_report in report.get("characters", []):
+            heuristics = char_report.get("targets_created_heuristically", [])
+            if heuristics:
+                print("WARNING: Character '{0}' has synthesized inert bones added for compliance: {1}".format(
+                    char_report.get("character_id"),
+                    ", ".join(heuristics)
+                ))
+    else:
+        heuristics = report.get("targets_created_heuristically", [])
+        if heuristics:
+            print("WARNING: Synthesized inert bones added for compliance: {0}".format(
+                ", ".join(heuristics)
+            ))
+
     print(success_message(report, report_path))
     return report
 

--- a/tests/test_addon_interface.py
+++ b/tests/test_addon_interface.py
@@ -1,0 +1,284 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+class AddonInterfaceTests(unittest.TestCase):
+    def setUp(self):
+        # Save original environment variable to prevent polluting other tests
+        import os
+        self.orig_env_root = os.environ.get("OPEN_JAYWALKER_OUTPUT_ROOT")
+
+        # Create a mock bpy module hierarchy
+        self.fake_bpy = types.ModuleType("bpy")
+        self.fake_bpy.app = types.ModuleType("bpy.app")
+        self.fake_bpy.app.handlers = types.ModuleType("bpy.app.handlers")
+        self.fake_bpy.app.handlers.persistent = lambda x: x  # decorator mock
+        
+        self.fake_bpy.types = types.SimpleNamespace(
+            Operator=object,
+            Panel=object,
+            PropertyGroup=object,
+            AddonPreferences=object,
+            Scene=types.SimpleNamespace,
+        )
+        self.fake_bpy.props = types.SimpleNamespace(
+            BoolProperty=mock.Mock(return_value=mock.Mock()),
+            IntProperty=mock.Mock(return_value=mock.Mock()),
+            StringProperty=mock.Mock(return_value=mock.Mock()),
+            EnumProperty=mock.Mock(return_value=mock.Mock()),
+            PointerProperty=mock.Mock(return_value=mock.Mock()),
+        )
+        self.fake_bpy.ops = types.SimpleNamespace(
+            object=types.SimpleNamespace(
+                mode_set=mock.Mock()
+            )
+        )
+        self.fake_bpy.path = types.SimpleNamespace(
+            abspath=lambda x: x
+        )
+        self.fake_bpy.data = types.SimpleNamespace(
+            objects=[],
+            collections=[],
+            scenes=[]
+        )
+        
+        # Patch sys.modules with our mocked bpy packages
+        self.sys_modules_patch = {
+            "bpy": self.fake_bpy,
+            "bpy.app": self.fake_bpy.app,
+            "bpy.app.handlers": self.fake_bpy.app.handlers
+        }
+        self.sys_modules_patcher = mock.patch.dict(sys.modules, self.sys_modules_patch)
+        self.sys_modules_patcher.start()
+        
+        # Reload/import the addon modules
+        if "addon.state" in sys.modules:
+            del sys.modules["addon.state"]
+        if "addon.operators" in sys.modules:
+            del sys.modules["addon.operators"]
+        if "addon.ui" in sys.modules:
+            del sys.modules["addon.ui"]
+            
+        self.state = importlib.import_module("addon.state")
+        self.operators = importlib.import_module("addon.operators")
+        self.ui = importlib.import_module("addon.ui")
+
+    def tearDown(self):
+        import os
+        self.sys_modules_patcher.stop()
+        if self.orig_env_root is not None:
+            os.environ["OPEN_JAYWALKER_OUTPUT_ROOT"] = self.orig_env_root
+        elif "OPEN_JAYWALKER_OUTPUT_ROOT" in os.environ:
+            del os.environ["OPEN_JAYWALKER_OUTPUT_ROOT"]
+
+    def test_operators_clear_state_properties(self):
+        # Test that run_pipeline and clean operators clear synthesized bones state
+        mock_settings = types.SimpleNamespace(
+            has_plan=True,
+            built=True,
+            synthesized_bones_csv="Full_Fingers_Left",
+            synthesized_bones_by_character_csv="char0 (Full_Fingers_Left)"
+        )
+        mock_context = types.SimpleNamespace(
+            scene=types.SimpleNamespace(open_jaywalker=mock_settings),
+            preferences=types.SimpleNamespace(addons={
+                "addon": types.SimpleNamespace(preferences=types.SimpleNamespace(output_dir="", dev_reload=False))
+            })
+        )
+        
+        with mock.patch("addon.operators._addon_prefs") as mock_prefs, \
+             mock.patch("addon.operators.purge_previous_generated_artifacts") as mock_purge, \
+             mock.patch("armature_inspector.inspector.inspect_scene", return_value=None):
+            mock_prefs.return_value = types.SimpleNamespace(output_dir="C:/tmp", dev_reload=False)
+            
+            clean_op = self.operators.OJ_OT_clean()
+            clean_op.report = mock.Mock()
+            clean_op.execute(mock_context)
+            
+            self.assertEqual(mock_settings.synthesized_bones_csv, "")
+            self.assertEqual(mock_settings.synthesized_bones_by_character_csv, "")
+            self.assertFalse(mock_settings.built)
+            
+            # Re-populate
+            mock_settings.synthesized_bones_csv = "Full_Fingers_Left"
+            mock_settings.synthesized_bones_by_character_csv = "char0 (Full_Fingers_Left)"
+            
+            run_op = self.operators.OJ_OT_run_pipeline()
+            run_op.report = mock.Mock()
+            run_op.execute(mock_context)
+            
+            self.assertEqual(mock_settings.synthesized_bones_csv, "")
+            self.assertEqual(mock_settings.synthesized_bones_by_character_csv, "")
+            self.assertFalse(mock_settings.has_plan)
+            self.assertFalse(mock_settings.built)
+
+    def test_operator_build_populates_state_and_reports_warning_single(self):
+        mock_settings = types.SimpleNamespace(
+            has_plan=True,
+            built=False,
+            asset_dir="/x",
+            packaging_mode="inplace_only",
+            export_gltf=False,
+            build_succeeded=0,
+            build_failed=0,
+            failed_characters_csv="",
+            synthesized_bones_csv="",
+            synthesized_bones_by_character_csv=""
+        )
+        mock_context = types.SimpleNamespace(
+            scene=types.SimpleNamespace(open_jaywalker=mock_settings),
+            window=types.SimpleNamespace(cursor_set=mock.Mock()),
+            preferences=types.SimpleNamespace(addons={
+                "addon": types.SimpleNamespace(preferences=types.SimpleNamespace(output_dir="", dev_reload=False))
+            })
+        )
+        
+        report_data = {
+            "built_core_targets": ["Hip", "Root"],
+            "targets_created_heuristically": ["Full_Fingers_Left", "Full_Fingers_Right"]
+        }
+        
+        with mock.patch("addon.operators._addon_prefs") as mock_prefs, \
+             mock.patch("asam_human_builder.build_runner.run_build", return_value=report_data) as mock_run_build, \
+             mock.patch("asam_human_builder.builder.success_message", return_value="ASAM human built"):
+            mock_prefs.return_value = types.SimpleNamespace(output_dir="C:/tmp", dev_reload=False)
+            
+            build_op = self.operators.OJ_OT_build()
+            build_op.report = mock.Mock()
+            build_op.execute(mock_context)
+            
+            self.assertTrue(mock_settings.built)
+            self.assertEqual(mock_settings.synthesized_bones_csv, "Full_Fingers_Left, Full_Fingers_Right")
+            self.assertEqual(mock_settings.synthesized_bones_by_character_csv, "")
+            
+            build_op.report.assert_any_call(
+                {'WARNING'},
+                "Synthesized inert bones added for compliance: Full_Fingers_Left, Full_Fingers_Right"
+            )
+
+    def test_operator_build_populates_state_and_reports_warning_crowd(self):
+        mock_settings = types.SimpleNamespace(
+            has_plan=True,
+            built=False,
+            asset_dir="/x",
+            packaging_mode="inplace_only",
+            export_gltf=False,
+            build_succeeded=0,
+            build_failed=0,
+            failed_characters_csv="",
+            synthesized_bones_csv="",
+            synthesized_bones_by_character_csv=""
+        )
+        mock_context = types.SimpleNamespace(
+            scene=types.SimpleNamespace(open_jaywalker=mock_settings),
+            window=types.SimpleNamespace(cursor_set=mock.Mock()),
+            preferences=types.SimpleNamespace(addons={
+                "addon": types.SimpleNamespace(preferences=types.SimpleNamespace(output_dir="", dev_reload=False))
+            })
+        )
+        
+        report_data = {
+            "characters": [
+                {
+                    "character_id": "Hero000",
+                    "targets_created_heuristically": ["Full_Fingers_Left"]
+                },
+                {
+                    "character_id": "Hero001",
+                    "targets_created_heuristically": ["Full_Toes_Right"]
+                }
+            ],
+            "failed_characters": []
+        }
+        
+        with mock.patch("addon.operators._addon_prefs") as mock_prefs, \
+             mock.patch("asam_human_builder.build_runner.run_build", return_value=report_data) as mock_run_build, \
+             mock.patch("asam_human_builder.builder.success_message", return_value="Crowd built"):
+            mock_prefs.return_value = types.SimpleNamespace(output_dir="C:/tmp", dev_reload=False)
+            
+            build_op = self.operators.OJ_OT_build()
+            build_op.report = mock.Mock()
+            build_op.execute(mock_context)
+            
+            self.assertTrue(mock_settings.built)
+            self.assertEqual(mock_settings.synthesized_bones_csv, "")
+            self.assertEqual(mock_settings.synthesized_bones_by_character_csv, "Hero000 (Full_Fingers_Left) | Hero001 (Full_Toes_Right)")
+            
+            build_op.report.assert_any_call(
+                {'WARNING'},
+                "Synthesized inert bones added for compliance: Hero000 (Full_Fingers_Left), Hero001 (Full_Toes_Right)"
+            )
+
+    def test_ui_draw_renders_warnings_without_crash(self):
+        class MockLayout:
+            def __init__(self):
+                self.alert = False
+                
+            def separator(self):
+                pass
+                
+            def label(self, text="", icon='NONE'):
+                pass
+                
+            def operator(self, name, icon='NONE'):
+                pass
+                
+            def prop(self, data, prop_name, text="", icon='NONE', emboss=True):
+                pass
+                
+            def row(self):
+                return MockLayout()
+                
+            def box(self):
+                return MockLayout()
+                
+            def column(self, align=False):
+                return MockLayout()
+
+        mock_layout = MockLayout()
+        
+        mock_settings = types.SimpleNamespace(
+            built=True,
+            has_plan=True,
+            is_crowd=False,
+            build_succeeded=1,
+            build_failed=0,
+            failed_characters_csv="",
+            synthesized_bones_csv="Full_Fingers_Left, Full_Fingers_Right",
+            synthesized_bones_by_character_csv="",
+            asset_dir="/x",
+            recommended_armature="Rig",
+            mapped=28,
+            total=28,
+            missing_csv="",
+            missing_by_target_csv="",
+            review_flags_csv="",
+            character_ids_csv="",
+            character_count=1,
+            show_details=False,
+            packaging_mode="inplace_only",
+            export_gltf=False
+        )
+        mock_context = types.SimpleNamespace(scene=types.SimpleNamespace(open_jaywalker=mock_settings))
+        
+        panel = self.ui.OJ_PT_panel()
+        panel.layout = mock_layout
+        
+        panel.draw(mock_context)
+        
+        # Test crowd
+        mock_settings.is_crowd = True
+        mock_settings.synthesized_bones_csv = ""
+        mock_settings.synthesized_bones_by_character_csv = "Hero000 (Full_Fingers_Left) | Hero001 (Full_Toes_Right)"
+        
+        panel.draw(mock_context)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_build_runner.py
+++ b/tests/test_build_runner.py
@@ -104,5 +104,62 @@ class RunBuildPackagingTests(unittest.TestCase):
             self.assertIn("export_error", report)
 
 
+class RunBuildWarningTests(unittest.TestCase):
+    def test_single_character_warning_logged(self):
+        import io
+        spec = {"generated_collection_name": "ASAM_A", "name": "SPEC"}
+        resolved = {"crowd": False, "asset_name": "A", "specs": [spec]}
+        report_data = {
+            "asset_name": "A",
+            "targets_created_heuristically": ["Full_Fingers_Left", "Full_Fingers_Right"]
+        }
+        
+        f = io.StringIO()
+        with mock.patch("sys.stdout", new=f):
+            with mock.patch.object(build_runner, "build_character_specs_from_asset_dir", return_value=resolved), \
+                 mock.patch.object(build_runner, "build_armature_in_blender", return_value={"exec": True}), \
+                 mock.patch.object(build_runner, "write_builder_report", return_value=(report_data, Path("/x/builder_report.json"))), \
+                 mock.patch.object(build_runner, "print_builder_summary"):
+                build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
+                
+        output = f.getvalue()
+        self.assertIn("WARNING: Synthesized inert bones added for compliance: Full_Fingers_Left, Full_Fingers_Right", output)
+
+    def test_crowd_warning_logged(self):
+        import io
+        resolved = {
+            "crowd": True,
+            "asset_name": "Crowd",
+            "wrapper_collection_name": "Crowd_Humans",
+            "decomposition": {"source_armature": "Root"},
+            "character_specs": [("c0", "SPEC0"), ("c1", "SPEC1")],
+        }
+        crowd_report = {
+            "characters": [
+                {
+                    "character_id": "c0",
+                    "targets_created_heuristically": ["Full_Fingers_Left"]
+                },
+                {
+                    "character_id": "c1",
+                    "targets_created_heuristically": ["Full_Toes_Right"]
+                }
+            ],
+            "failed_characters": []
+        }
+        
+        f = io.StringIO()
+        with mock.patch("sys.stdout", new=f):
+            with mock.patch.object(build_runner, "build_character_specs_from_asset_dir", return_value=resolved), \
+                 mock.patch.object(build_runner, "build_crowd_in_blender", return_value={"exec": True}), \
+                 mock.patch.object(build_runner, "build_crowd_builder_report", return_value=crowd_report), \
+                 mock.patch.object(build_runner, "write_crowd_builder_report", return_value=(crowd_report, Path("/x/builder_report.json"))):
+                build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
+                
+        output = f.getvalue()
+        self.assertIn("WARNING: Character 'c0' has synthesized inert bones added for compliance: Full_Fingers_Left", output)
+        self.assertIn("WARNING: Character 'c1' has synthesized inert bones added for compliance: Full_Toes_Right", output)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request implements **Issue #70**: Surface warnings for synthesized, inert bones (e.g., fingers) added for compliance.

### Changes
- **addon/state.py**: Added `synthesized_bones_csv` and `synthesized_bones_by_character_csv` settings.
- **src/asam_human_builder/build_runner.py**: Prints console warnings for synthesized bones during `run_build`.
- **addon/operators.py**: Saves warning data to the new properties on build and clears it on pipeline reset. Calls `self.report({'WARNING'}, ...)` to show a warning bar.
- **addon/ui.py**: Renders a warning alert box in the N-panel under Build Results when synthesized bones exist.
- **tests/test_build_runner.py**: Verifies console logs for warning triggers.
- **tests/test_addon_interface.py**: New unit test verifying operator warnings, state updates, and UI draw calls.

Closes #70
