### PR TITLE
feat(addon): automatically hide source armature and add visibility toggle

### DIFF
--- a/addon/operators.py
+++ b/addon/operators.py
@@ -26,6 +26,7 @@ class OJ_OT_run_pipeline(bpy.types.Operator):
         settings.built = False
         settings.synthesized_bones_csv = ""
         settings.synthesized_bones_by_character_csv = ""
+        settings.show_generated_armature = True
 
         prefs = _addon_prefs(context)
         if prefs.output_dir:
@@ -170,5 +171,6 @@ class OJ_OT_clean(bpy.types.Operator):
         s.built = False
         s.synthesized_bones_csv = ""
         s.synthesized_bones_by_character_csv = ""
+        s.show_generated_armature = True
         self.report({'INFO'}, "Removed {0} generated object(s)/collection(s).".format(removed))
         return {'FINISHED'}

--- a/addon/state.py
+++ b/addon/state.py
@@ -3,10 +3,49 @@
 import bpy
 
 
+def update_show_generated_armature(self, context):
+    if context is None:
+        return
+    scene = getattr(context, "scene", None)
+    if scene is None:
+        return
+    objects = getattr(scene, "objects", None)
+    if objects is None:
+        return
+
+    show = getattr(self, "show_generated_armature", True)
+    for obj in objects:
+        if obj is None:
+            continue
+        if getattr(obj, "type", None) == "ARMATURE":
+            is_generated = False
+            if hasattr(obj, "get") and callable(obj.get):
+                try:
+                    is_generated = bool(obj.get("open_jaywalker_generated"))
+                except Exception:
+                    pass
+            if not is_generated:
+                is_generated = bool(getattr(obj, "open_jaywalker_generated", False))
+
+            if is_generated:
+                hide_set = getattr(obj, "hide_set", None)
+                if callable(hide_set):
+                    try:
+                        hide_set(not show)
+                    except Exception:
+                        pass
+
+
 class OJSettings(bpy.types.PropertyGroup):
     has_plan: bpy.props.BoolProperty(default=False)
     built: bpy.props.BoolProperty(default=False)
     show_details: bpy.props.BoolProperty(default=False)
+    show_generated_armature: bpy.props.BoolProperty(
+        name="Show Armature",
+        description="Show or hide the generated ASAM armature(s) in the viewport",
+        default=True,
+        update=update_show_generated_armature,
+    )
     asset_dir: bpy.props.StringProperty(default="")
     recommended_armature: bpy.props.StringProperty(default="")
     mapped: bpy.props.IntProperty(default=0)

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -80,6 +80,7 @@ class OJ_PT_panel(bpy.types.Panel):
             res_box = layout.box()
             res_box.label(text="Build Results", icon='INFO')
             res_col = res_box.column(align=True)
+            res_col.prop(s, "show_generated_armature")
             if s.is_crowd:
                 res_col.label(text="Succeeded: {0}".format(s.build_succeeded), icon='CHECKMARK')
                 if s.build_failed > 0:

--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -148,6 +148,9 @@ def _hide_source_objects(bpy_module, source_armature, build_spec) -> List[str]:
     targets = []
     if source_armature is not None:
         targets.append(source_armature)
+    metarig = bpy_module.data.objects.get("metarig")
+    if metarig is not None and getattr(metarig, "type", None) == "ARMATURE" and metarig not in targets:
+        targets.append(metarig)
     for record in build_spec.get("mesh_binding", {}).get("meshes", []):
         mesh = bpy_module.data.objects.get(record.get("mesh_name"))
         if mesh is not None and mesh not in targets:

--- a/tests/test_addon_interface.py
+++ b/tests/test_addon_interface.py
@@ -280,5 +280,122 @@ class AddonInterfaceTests(unittest.TestCase):
         
         panel.draw(mock_context)
 
+    def test_show_generated_armature_toggle_and_ui(self):
+        # 1. Test update callback toggles hide_set on generated armatures
+        mock_generated_armature = types.SimpleNamespace(
+            type="ARMATURE",
+            open_jaywalker_generated=True,
+            hide_set=mock.Mock()
+        )
+        mock_other_object = types.SimpleNamespace(
+            type="MESH",
+            open_jaywalker_generated=True,
+            hide_set=mock.Mock()
+        )
+        mock_non_gen_armature = types.SimpleNamespace(
+            type="ARMATURE",
+            open_jaywalker_generated=False,
+            hide_set=mock.Mock()
+        )
+        
+        class DictLikeMockObj:
+            def __init__(self, type_str, gen_val):
+                self.type = type_str
+                self.props = {"open_jaywalker_generated": gen_val}
+                self.hide_set = mock.Mock()
+            def get(self, key, default=None):
+                return self.props.get(key, default)
+
+        mock_dict_gen_armature = DictLikeMockObj("ARMATURE", True)
+        mock_dict_non_gen_armature = DictLikeMockObj("ARMATURE", False)
+
+        mock_settings = types.SimpleNamespace(show_generated_armature=False)
+        mock_context = types.SimpleNamespace(
+            scene=types.SimpleNamespace(
+                objects=[
+                    mock_generated_armature,
+                    mock_other_object,
+                    mock_non_gen_armature,
+                    mock_dict_gen_armature,
+                    mock_dict_non_gen_armature,
+                    None
+                ]
+            )
+        )
+
+        self.state.update_show_generated_armature(mock_settings, mock_context)
+        
+        mock_generated_armature.hide_set.assert_called_once_with(True)
+        mock_other_object.hide_set.assert_not_called()
+        mock_non_gen_armature.hide_set.assert_not_called()
+        mock_dict_gen_armature.hide_set.assert_called_once_with(True)
+        mock_dict_non_gen_armature.hide_set.assert_not_called()
+        
+        mock_generated_armature.hide_set.reset_mock()
+        mock_dict_gen_armature.hide_set.reset_mock()
+
+        mock_settings.show_generated_armature = True
+        self.state.update_show_generated_armature(mock_settings, mock_context)
+        mock_generated_armature.hide_set.assert_called_once_with(False)
+        mock_dict_gen_armature.hide_set.assert_called_once_with(False)
+
+        # 2. Test that UI renders the checkbox without crashing
+        class MockLayout:
+            def __init__(self):
+                self.props_drawn = []
+                
+            def separator(self):
+                pass
+                
+            def label(self, text="", icon='NONE'):
+                pass
+                
+            def operator(self, name, icon='NONE'):
+                pass
+                
+            def prop(self, data, prop_name, text="", icon='NONE', emboss=True):
+                self.props_drawn.append((data, prop_name))
+                
+            def row(self):
+                return self
+                
+            def box(self):
+                return self
+                
+            def column(self, align=False):
+                return self
+
+        mock_layout = MockLayout()
+        ui_settings = types.SimpleNamespace(
+            built=True,
+            has_plan=True,
+            is_crowd=False,
+            build_succeeded=1,
+            build_failed=0,
+            failed_characters_csv="",
+            synthesized_bones_csv="",
+            synthesized_bones_by_character_csv="",
+            asset_dir="/x",
+            recommended_armature="Rig",
+            mapped=28,
+            total=28,
+            missing_csv="",
+            missing_by_target_csv="",
+            review_flags_csv="",
+            character_ids_csv="",
+            character_count=1,
+            show_details=False,
+            packaging_mode="inplace_only",
+            export_gltf=False,
+            show_generated_armature=True
+        )
+        ui_context = types.SimpleNamespace(scene=types.SimpleNamespace(open_jaywalker=ui_settings))
+        
+        panel = self.ui.OJ_PT_panel()
+        panel.layout = mock_layout
+        panel.draw(ui_context)
+        
+        self.assertIn((ui_settings, "show_generated_armature"), mock_layout.props_drawn)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -658,6 +658,21 @@ class AsamHumanBuilderTests(unittest.TestCase):
         report = build_builder_report(build_spec, execution_result)
         self.assertIn("Armature", report["hidden_source_objects"])
 
+    def test_hide_source_objects_hides_metarig_if_exists(self):
+        """_hide_source_objects hides metarig if it exists and is an armature."""
+        from asam_human_builder.blender_builder import _hide_source_objects
+        bpy_module = _FakeBpy()
+        build_spec = {"mesh_binding": {"meshes": []}}
+        source_arm = bpy_module.add_source_armature("Armature")
+        hidden = _hide_source_objects(bpy_module, source_arm, build_spec)
+        self.assertNotIn("metarig", hidden)
+
+        metarig_arm = bpy_module.data.armatures.new("metarig")
+        metarig_obj = bpy_module.data.objects.new("metarig", metarig_arm)
+        hidden2 = _hide_source_objects(bpy_module, source_arm, build_spec)
+        self.assertIn("metarig", hidden2)
+        self.assertTrue(metarig_obj.hide_get())
+
     def test_grp_root_location_set_to_bbox_ground_center(self):
         """Grp_Root empty's location must equal the source-frame bbox_ground_center."""
         asset_dir = _copy_asset_folder("openmatexamplehuman")


### PR DESCRIPTION
This pull request implements **Issue #76**: Automatically hide source armatures (like `metarig`) after build and add armature-level visibility toggle in UI.

### Changes
- **src/asam_human_builder/blender_builder.py**: Updated `_hide_source_objects` to always locate and hide any `metarig` armature object present in the scene.
- **addon/state.py**: Added `show_generated_armature` Boolean property to `OJSettings` along with a defensive update callback that toggles visibility (`hide_set`) on all generated armatures.
- **addon/operators.py**: Ensures the toggle resets to `True` when clearing rigs (`OJ_OT_clean`) or running the plan pipeline (`OJ_OT_run_pipeline`).
- **addon/ui.py**: Added the "Show Armature" checkbox to the N-panel under the Build Results section.
- **tests/test_asam_human_builder.py**: Added tests for `_hide_source_objects` metarig hiding behavior.
- **tests/test_addon_interface.py**: Added tests checking that toggling `show_generated_armature` correctly hides/shows generated armatures and that the UI draw method renders the property.

Closes #76
