### PR TITLE
Fix Neck/Upper_Spine overlap on LowPolyCharacter4 (#73)

### DIFF
--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -1489,7 +1489,7 @@ def _plan_single_spine_split(resolved_targets: Dict[str, dict], context: dict) -
 def _demote_neck_coincident_upper_spine(resolved_targets: Dict[str, dict], context: dict) -> None:
     """Keep ASAM Upper_Spine strictly below Neck (issue #73).
 
-    On some rigs the spine-segment chosen for Upper_Spine has its head on the very
+    On some rigs the spine-segment chosen for Upper_Spine has its head at or above the
     joint the Neck bone starts from (e.g. Rigify `DEF-spine.004` head == `neck` head),
     so the two bones share a joint and render overlapping. The structural channel cannot
     see this — the colliding joint belongs to the parallel name-alias Neck bone, not the

--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -1486,6 +1486,69 @@ def _plan_single_spine_split(resolved_targets: Dict[str, dict], context: dict) -
             payload["notes"].append("single_spine_geometric_split")
 
 
+def _demote_neck_coincident_upper_spine(resolved_targets: Dict[str, dict], context: dict) -> None:
+    """Keep ASAM Upper_Spine strictly below Neck (issue #73).
+
+    On some rigs the spine-segment chosen for Upper_Spine has its head on the very
+    joint the Neck bone starts from (e.g. Rigify `DEF-spine.004` head == `neck` head),
+    so the two bones share a joint and render overlapping. The structural channel cannot
+    see this — the colliding joint belongs to the parallel name-alias Neck bone, not the
+    structural spine column — so we enforce the invariant here, after both targets have
+    resolved to concrete source bones.
+
+    When Upper_Spine's source head is not strictly below Neck's source head along the up
+    axis, re-point Upper_Spine to the nearest ancestor spine segment whose head IS strictly
+    below Neck (without stealing Lower_Spine's source). If no such segment exists, leave the
+    mapping unchanged and annotate it for review. Only acts on directly-mapped spine
+    segments; split/created/review mappings are left alone. Mutates `resolved_targets`."""
+    upper = resolved_targets.get("Upper_Spine", {})
+    neck = resolved_targets.get("Neck", {})
+    if upper.get("action") not in {"direct_map", "alias_map"}:
+        return
+    if neck.get("action") not in {"direct_map", "alias_map"}:
+        return
+
+    bones = context["bones"]
+    upper_bone = bones.get(upper.get("source_bone"))
+    neck_bone = bones.get(neck.get("source_bone"))
+    if upper_bone is None or neck_bone is None:
+        return
+
+    up = context["height_axis"]
+    sign = context["height_sign"]
+    eps = 1e-4
+    neck_h = neck_bone.head[up] * sign
+
+    # Already strictly below the neck joint -> nothing to do.
+    if upper_bone.head[up] * sign < neck_h - eps:
+        return
+
+    lower_source = resolved_targets.get("Lower_Spine", {}).get("source_bone")
+
+    # Walk up the source parent chain to the nearest ancestor strictly below the neck.
+    chosen = None
+    node = upper_bone.parent
+    while node is not None:
+        if node == lower_source:
+            break  # don't collide with Lower_Spine; treat as degenerate
+        candidate = bones.get(node)
+        if candidate is None:
+            break
+        if candidate.head[up] * sign < neck_h - eps:
+            chosen = node
+            break
+        node = candidate.parent
+
+    if chosen is None:
+        if "neck_coincident_upper_spine_unresolved" not in upper["notes"]:
+            upper["notes"].append("neck_coincident_upper_spine_unresolved")
+        return
+
+    upper["source_bone"] = chosen
+    if "neck_coincident_upper_spine_demoted" not in upper["notes"]:
+        upper["notes"].append("neck_coincident_upper_spine_demoted")
+
+
 def _build_review_flags(resolved_targets: Dict[str, dict], root_resolution: dict, context: dict) -> List[str]:
     flags: Set[str] = set()
     actual_roots = [bone for bone in context["bones"].values() if bone.parent is None]

--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -610,6 +610,7 @@ def classify_armature(asset_name: str, armature_input: ArmatureInput) -> dict:
     resolved_targets = _resolve_targets(target_candidates, context)
     _reconcile_hip_to_spine_pivot(resolved_targets, context)
     _plan_single_spine_split(resolved_targets, context)
+    _demote_neck_coincident_upper_spine(resolved_targets, context)
     root_resolution = _resolve_root_compliance(resolved_targets, target_candidates.get("Root", []), context)
     mapped_bones = {
         payload["source_bone"]

--- a/tests/fixtures/LowPolyCharacter4/build_plan.json
+++ b/tests/fixtures/LowPolyCharacter4/build_plan.json
@@ -12,7 +12,7 @@
         "target": "Lower_Spine"
       },
       {
-        "source": "DEF-spine.004",
+        "source": "DEF-spine.003",
         "target": "Upper_Spine"
       },
       {
@@ -113,7 +113,8 @@
         "target": "Full_Fingers_Right",
         "parent": "Hand_Right"
       }
-    ]
+    ],
+    "split": []
   },
   "root_resolutions": [
     {
@@ -468,7 +469,7 @@
       "role": "deform"
     },
     {
-      "bone_name": "DEF-spine.003",
+      "bone_name": "DEF-spine.004",
       "reason": "supporting_chain_detail",
       "origin": "primary",
       "role": "deform"

--- a/tests/fixtures/LowPolyCharacter4/classifier_report.json
+++ b/tests/fixtures/LowPolyCharacter4/classifier_report.json
@@ -1530,7 +1530,7 @@
           "role": "deform"
         },
         {
-          "bone_name": "DEF-spine.003",
+          "bone_name": "DEF-spine.004",
           "reason": "supporting_chain_detail",
           "origin": "primary",
           "role": "deform"

--- a/tests/fixtures/LowPolyCharacter4/classifier_report.json
+++ b/tests/fixtures/LowPolyCharacter4/classifier_report.json
@@ -782,7 +782,7 @@
           "notes": []
         },
         "Upper_Spine": {
-          "source_bone": "DEF-spine.004",
+          "source_bone": "DEF-spine.003",
           "confidence": 0.736,
           "action": "alias_map",
           "decision": "structure_confirmed_by_name",
@@ -794,7 +794,9 @@
             "source_origin": "primary",
             "role": "deform"
           },
-          "notes": []
+          "notes": [
+            "neck_coincident_upper_spine_demoted"
+          ]
         },
         "Neck": {
           "source_bone": "neck",
@@ -2744,7 +2746,7 @@
       "notes": []
     },
     "Upper_Spine": {
-      "source_bone": "DEF-spine.004",
+      "source_bone": "DEF-spine.003",
       "confidence": 0.736,
       "action": "alias_map",
       "decision": "structure_confirmed_by_name",
@@ -2756,7 +2758,9 @@
         "source_origin": "primary",
         "role": "deform"
       },
-      "notes": []
+      "notes": [
+        "neck_coincident_upper_spine_demoted"
+      ]
     },
     "Neck": {
       "source_bone": "neck",

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -868,6 +868,36 @@ class AsamHumanBuilderTests(unittest.TestCase):
             self.assertEqual(preserved_bone["source_bone"], source_name)
             self.assertEqual(preserved_bone["semantic_action"], "preserve_paired_pelvis")
 
+    def test_lowpoly_central_chain_is_monotonic_and_continuous(self):
+        # Regression for #73: the spanned central chain Hip -> Lower_Spine ->
+        # Upper_Spine -> Neck -> Head on the real LowPolyCharacter4 rig must render as
+        # an upright, non-overlapping spine. Overlap can only arise from a fold-back
+        # (a child head sitting at/below its parent along the up axis); pin against it.
+        asset_dir = _copy_asset_folder("LowPolyCharacter4")
+        write_asset_report(asset_dir)
+
+        _, build_plan, build_spec = build_armature_spec_from_asset_dir(asset_dir)
+
+        up = build_plan["placement_metadata"]["up_axis"]
+        up_index = int(up["index"])
+        up_sign = int(up.get("sign", 1))
+        chain = ["Hip", "Lower_Spine", "Upper_Spine", "Neck", "Head"]
+        bones = [_spec_bone(build_spec, name) for name in chain]
+
+        # 1. Strict monotonic ascent along the up axis: no inversion / fold-back / overlap.
+        for parent, child in zip(bones, bones[1:]):
+            self.assertGreater(
+                child["head"][up_index] * up_sign,
+                parent["head"][up_index] * up_sign,
+                "{0} head must sit strictly above {1} head along the up axis".format(
+                    child["name"], parent["name"]
+                ),
+            )
+
+        # 2. End-to-end continuity: each spanned bone's tail meets its child's head.
+        for parent, child in zip(bones, bones[1:]):
+            _assert_vec_almost_equal(self, parent["tail"], child["head"])
+
     def test_repaired_paired_pelvis_creates_centered_hip_at_pelvis_pointing_to_spine(self):
         classifier_report = _base_classifier_report()
         build_plan = _base_build_plan()

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from typing import Optional
@@ -1723,6 +1724,103 @@ class SingleSpineSplitTests(unittest.TestCase):
         self.assertNotEqual(sm["Lower_Spine"]["action"], "split_in_builder")
         self.assertNotEqual(sm["Upper_Spine"]["action"], "split_in_builder")
         self.assertEqual(build_plan["actions"]["split"], [])
+
+
+from phase3_classifier.classifier import _demote_neck_coincident_upper_spine
+
+
+def _guard_bone(head, parent=None):
+    # Only .head (index-able by axis) and .parent (name or None) are read by the guard.
+    return types.SimpleNamespace(head=list(head), parent=parent)
+
+
+def _guard_ctx(bones):
+    return {
+        "bones": bones,
+        "height_axis": 2,   # z is up in these fixtures
+        "height_sign": 1,
+        "height_span": 2.0,
+    }
+
+
+def _guard_payload(source_bone, action="alias_map", notes=None):
+    return {
+        "source_bone": source_bone,
+        "action": action,
+        "confidence": 0.7,
+        "notes": list(notes or []),
+    }
+
+
+class SpineNeckGuardTests(unittest.TestCase):
+    def test_demotes_upper_spine_when_head_coincides_with_neck(self):
+        bones = {
+            "s1": _guard_bone((0.0, 0.0, 1.0890), parent="hip"),
+            "s2": _guard_bone((0.0, 0.0, 1.2145), parent="s1"),
+            "s3": _guard_bone((0.0, 0.0, 1.3741), parent="s2"),
+            "s4": _guard_bone((0.0, 0.0, 1.5338), parent="s3"),  # head == neck head
+            "neck": _guard_bone((0.0, 0.0, 1.5338), parent="mch"),
+        }
+        resolved = {
+            "Lower_Spine": _guard_payload("s1"),
+            "Upper_Spine": _guard_payload("s4"),
+            "Neck": _guard_payload("neck", action="direct_map"),
+        }
+        _demote_neck_coincident_upper_spine(resolved, _guard_ctx(bones))
+        self.assertEqual(resolved["Upper_Spine"]["source_bone"], "s3")
+        self.assertIn(
+            "neck_coincident_upper_spine_demoted",
+            resolved["Upper_Spine"]["notes"],
+        )
+
+    def test_noop_when_upper_spine_already_below_neck(self):
+        bones = {
+            "s1": _guard_bone((0.0, 0.0, 1.0890), parent="hip"),
+            "s3": _guard_bone((0.0, 0.0, 1.3741), parent="s1"),
+            "neck": _guard_bone((0.0, 0.0, 1.5338), parent="mch"),
+        }
+        resolved = {
+            "Lower_Spine": _guard_payload("s1"),
+            "Upper_Spine": _guard_payload("s3"),
+            "Neck": _guard_payload("neck", action="direct_map"),
+        }
+        _demote_neck_coincident_upper_spine(resolved, _guard_ctx(bones))
+        self.assertEqual(resolved["Upper_Spine"]["source_bone"], "s3")
+        self.assertEqual(resolved["Upper_Spine"]["notes"], [])
+
+    def test_degenerate_leaves_mapping_and_annotates(self):
+        # Only spine bone below neck is Lower_Spine's own source -> nothing valid to pick.
+        bones = {
+            "s1": _guard_bone((0.0, 0.0, 1.0890), parent="hip"),
+            "s4": _guard_bone((0.0, 0.0, 1.5338), parent="s1"),  # head == neck head
+            "neck": _guard_bone((0.0, 0.0, 1.5338), parent="mch"),
+        }
+        resolved = {
+            "Lower_Spine": _guard_payload("s1"),
+            "Upper_Spine": _guard_payload("s4"),
+            "Neck": _guard_payload("neck", action="direct_map"),
+        }
+        _demote_neck_coincident_upper_spine(resolved, _guard_ctx(bones))
+        self.assertEqual(resolved["Upper_Spine"]["source_bone"], "s4")
+        self.assertIn(
+            "neck_coincident_upper_spine_unresolved",
+            resolved["Upper_Spine"]["notes"],
+        )
+
+    def test_noop_when_upper_spine_is_split(self):
+        # Single-spine split assigns both spine targets to one bone; guard must not touch it.
+        bones = {
+            "s1": _guard_bone((0.0, 0.0, 1.2000), parent="hip"),
+            "neck": _guard_bone((0.0, 0.0, 1.5338), parent="mch"),
+        }
+        resolved = {
+            "Lower_Spine": _guard_payload("s1", action="split_in_builder"),
+            "Upper_Spine": _guard_payload("s1", action="split_in_builder"),
+            "Neck": _guard_payload("neck", action="direct_map"),
+        }
+        _demote_neck_coincident_upper_spine(resolved, _guard_ctx(bones))
+        self.assertEqual(resolved["Upper_Spine"]["source_bone"], "s1")
+        self.assertEqual(resolved["Upper_Spine"]["notes"], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_phase3_classifier.py
+++ b/tests/test_phase3_classifier.py
@@ -24,6 +24,7 @@ from phase3_classifier.classifier import (  # noqa: E402
     _compute_vertex_group_coverage,
     _compute_deform_purity,
     _compute_selection_tiebreaker,
+    _demote_neck_coincident_upper_spine,
     _detect_convention,
     _normalize_bone_name,
     _detect_family_tags,
@@ -1726,9 +1727,6 @@ class SingleSpineSplitTests(unittest.TestCase):
         self.assertEqual(build_plan["actions"]["split"], [])
 
 
-from phase3_classifier.classifier import _demote_neck_coincident_upper_spine
-
-
 def _guard_bone(head, parent=None):
     # Only .head (index-able by axis) and .parent (name or None) are read by the guard.
     return types.SimpleNamespace(head=list(head), parent=parent)
@@ -1821,6 +1819,27 @@ class SpineNeckGuardTests(unittest.TestCase):
         _demote_neck_coincident_upper_spine(resolved, _guard_ctx(bones))
         self.assertEqual(resolved["Upper_Spine"]["source_bone"], "s1")
         self.assertEqual(resolved["Upper_Spine"]["notes"], [])
+
+    def test_demotes_with_negative_height_sign(self):
+        # Up is the -z direction (height_sign=-1): "higher" means more negative z.
+        bones = {
+            "s1": _guard_bone((0.0, 0.0, -1.0890), parent="hip"),
+            "s3": _guard_bone((0.0, 0.0, -1.3741), parent="s1"),
+            "s4": _guard_bone((0.0, 0.0, -1.5338), parent="s3"),  # head == neck head
+            "neck": _guard_bone((0.0, 0.0, -1.5338), parent="mch"),
+        }
+        ctx = {"bones": bones, "height_axis": 2, "height_sign": -1, "height_span": 2.0}
+        resolved = {
+            "Lower_Spine": _guard_payload("s1"),
+            "Upper_Spine": _guard_payload("s4"),
+            "Neck": _guard_payload("neck", action="direct_map"),
+        }
+        _demote_neck_coincident_upper_spine(resolved, ctx)
+        self.assertEqual(resolved["Upper_Spine"]["source_bone"], "s3")
+        self.assertIn(
+            "neck_coincident_upper_spine_demoted",
+            resolved["Upper_Spine"]["notes"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`Neck` and `Upper_Spine` rendered overlapping on the original Rigify `LowPolyCharacter4` rig. Root cause is **classifier spine→target assignment**, not the builder's spanning (which #73 originally suspected): the classifier could pick an `Upper_Spine` source segment (`DEF-spine.004`) whose head sits on the very joint the `Neck` bone (`neck`) starts from, so both bones emanate from the same joint and collide. The structural channel can't detect this — the colliding joint belongs to the parallel name-alias `Neck` bone, in a different resolution channel than the structural spine column — so the invariant is enforced after both targets resolve.

- Add a post-resolution guard `_demote_neck_coincident_upper_spine` in `classify_armature` (sibling to `_reconcile_hip_to_spine_pivot` / `_plan_single_spine_split`). When `Upper_Spine.head` is not strictly below `Neck.head` along the up axis, it re-points `Upper_Spine` to the nearest ancestor spine segment strictly below `Neck`, without stealing `Lower_Spine`'s source. Degenerate spines are left unchanged and annotated.
- Geometry/topology-driven (head positions + parent links), not naming — consistent with "build from whatever the mesh is weighted to."
- Clean rigs are a strict no-op (verified the glTF-reimported variant of the same asset stays unchanged), preserving the single-character invariant.

## Why it surfaced inconsistently

The asset exported to glTF and re-imported classifies `Upper_Spine → DEF-spine.003` (clean), because the glTF round-trip re-synthesizes bone tails and shifts the neck-boundary detection by one segment. The committed original-rig fixture reproduces the overlap; the glb variant masks it.

## Test Plan

- [x] New fixture regression `test_lowpoly_central_chain_is_monotonic_and_continuous` (builds the real fixture; asserts the central chain is strictly monotonic + end-to-end continuous). Fails before the fix, passes after.
- [x] 5 unit tests `SpineNeckGuardTests` (demote-on-coincidence, no-op-when-below, degenerate-annotate, no-op-when-split, negative height_sign).
- [x] Full suite green: `python -m unittest discover tests` → 322 OK.
- [x] glb-variant confirmed no-op (`Upper_Spine → DEF-spine.003`, no demotion note).

Closes #73