### PR TITLE
Implement unified export strategy for single and crowd rigs (#71, #79)

### DIFF
--- a/addon/__init__.py
+++ b/addon/__init__.py
@@ -36,6 +36,8 @@ _CLASSES = (
     state.OJSettings,
     operators.OJ_OT_run_pipeline,
     operators.OJ_OT_build,
+    operators.OJ_OT_export_blend,
+    operators.OJ_OT_export_gltf,
     operators.OJ_OT_open_output,
     operators.OJ_OT_clean,
     ui.OJ_PT_panel,

--- a/addon/operators.py
+++ b/addon/operators.py
@@ -98,10 +98,11 @@ class OJ_OT_build(bpy.types.Operator):
         context.window.cursor_set('WAIT')
         try:
             report = run_build(
-                asset_dir, 
-                bpy, 
-                packaging_mode=settings.packaging_mode,
-                export_gltf=settings.export_gltf
+                asset_dir,
+                bpy,
+                export_blend=settings.export_blend,
+                export_gltf=settings.export_gltf,
+                per_character=settings.per_character_export,
             )
         except Exception as exc:  # surface as an operator error, never crash
             self.report({'ERROR'}, "Build failed: {0}".format(exc))
@@ -143,6 +144,104 @@ class OJ_OT_build(bpy.types.Operator):
                     ", ".join(heuristics)
                 ))
 
+        return {'FINISHED'}
+
+
+class OJ_OT_export_blend(bpy.types.Operator):
+    bl_idname = "open_jaywalker.export_blend"
+    bl_label = "Export .blend"
+    bl_description = "Export the generated ASAM human(s) to .blend format"
+
+    @classmethod
+    def poll(cls, context):
+        s = context.scene.open_jaywalker
+        return bool(s.built) and bool(s.asset_dir)
+
+    def execute(self, context):
+        import json
+        settings = context.scene.open_jaywalker
+        prefs = _addon_prefs(context)
+        if getattr(prefs, "dev_reload", False):
+            from . import dev_reload
+            dev_reload.purge_pipeline_modules()
+        from asam_human_builder.blender_builder import (
+            export_generated_blend,
+            export_crowd_characters_blend,
+        )
+        asset_dir = Path(settings.asset_dir)
+        report_path = asset_dir / "builder_report.json"
+        if not report_path.exists():
+            self.report({'ERROR'}, "Builder report not found at {0}".format(report_path))
+            return {'CANCELLED'}
+        with report_path.open(encoding="utf-8") as fh:
+            report = json.load(fh)
+        wrapper_name = report.get("wrapper_collection_name")
+        if not wrapper_name:
+            wrapper_name = report.get("generated_collection_name")
+        if not wrapper_name:
+            self.report({'ERROR'}, "Cannot determine wrapper collection from builder report.")
+            return {'CANCELLED'}
+        try:
+            if settings.is_crowd and settings.per_character_export:
+                paths = export_crowd_characters_blend(bpy, wrapper_name, str(asset_dir))
+                self.report({'INFO'}, "Exported {0} .blend file(s) to {1}/blend/".format(len(paths), asset_dir))
+            else:
+                asset_name = report.get("asset_name", "output")
+                out_path = str(asset_dir / "{0}_asam.blend".format(asset_name))
+                export_generated_blend(bpy, wrapper_name, out_path)
+                self.report({'INFO'}, "Exported .blend to {0}".format(out_path))
+        except Exception as exc:
+            self.report({'ERROR'}, "Export failed: {0}".format(exc))
+            return {'CANCELLED'}
+        return {'FINISHED'}
+
+
+class OJ_OT_export_gltf(bpy.types.Operator):
+    bl_idname = "open_jaywalker.export_gltf"
+    bl_label = "Export .glb"
+    bl_description = "Export the generated ASAM human(s) to .glb format"
+
+    @classmethod
+    def poll(cls, context):
+        s = context.scene.open_jaywalker
+        return bool(s.built) and bool(s.asset_dir)
+
+    def execute(self, context):
+        import json
+        settings = context.scene.open_jaywalker
+        prefs = _addon_prefs(context)
+        if getattr(prefs, "dev_reload", False):
+            from . import dev_reload
+            dev_reload.purge_pipeline_modules()
+        from asam_human_builder.blender_builder import (
+            export_generated_gltf,
+            export_crowd_characters_gltf,
+        )
+        asset_dir = Path(settings.asset_dir)
+        report_path = asset_dir / "builder_report.json"
+        if not report_path.exists():
+            self.report({'ERROR'}, "Builder report not found at {0}".format(report_path))
+            return {'CANCELLED'}
+        with report_path.open(encoding="utf-8") as fh:
+            report = json.load(fh)
+        wrapper_name = report.get("wrapper_collection_name")
+        if not wrapper_name:
+            wrapper_name = report.get("generated_collection_name")
+        if not wrapper_name:
+            self.report({'ERROR'}, "Cannot determine wrapper collection from builder report.")
+            return {'CANCELLED'}
+        try:
+            if settings.is_crowd and settings.per_character_export:
+                paths = export_crowd_characters_gltf(bpy, wrapper_name, str(asset_dir))
+                self.report({'INFO'}, "Exported {0} .glb file(s) to {1}/glb/".format(len(paths), asset_dir))
+            else:
+                asset_name = report.get("asset_name", "output")
+                out_path = str(asset_dir / "{0}_asam.glb".format(asset_name))
+                export_generated_gltf(bpy, wrapper_name, out_path)
+                self.report({'INFO'}, "Exported .glb to {0}".format(out_path))
+        except Exception as exc:
+            self.report({'ERROR'}, "Export failed: {0}".format(exc))
+            return {'CANCELLED'}
         return {'FINISHED'}
 
 

--- a/addon/state.py
+++ b/addon/state.py
@@ -61,21 +61,18 @@ class OJSettings(bpy.types.PropertyGroup):
     failed_characters_csv: bpy.props.StringProperty(default="")
     synthesized_bones_csv: bpy.props.StringProperty(default="")
     synthesized_bones_by_character_csv: bpy.props.StringProperty(default="")
-    packaging_mode: bpy.props.EnumProperty(
-        name="Output",
-        description="How to package the generated ASAM human(s)",
-        items=[
-            ("inplace_export", "In-place + export .blend",
-             "Build in this file, then export only the ASAM result to <asset>_asam.blend"),
-            ("inplace_only", "In-place only",
-             "Build in this file; do not export a separate .blend"),
-            ("separate_only", "Separate file only",
-             "Export the ASAM result, then remove generated data from this file"),
-        ],
-        default="inplace_export",
+    export_blend: bpy.props.BoolProperty(
+        default=False,
+        name="Auto-export .blend",
+        description="Automatically export the generated ASAM result to .blend after build"
     )
     export_gltf: bpy.props.BoolProperty(
-        default=False, 
-        name="Export glTF / .glb",
-        description="Wrap and export the generated ASAM human to .glb format"
+        default=True,
+        name="Auto-export .glb",
+        description="Automatically export the generated ASAM result to .glb format after build"
+    )
+    per_character_export: bpy.props.BoolProperty(
+        default=False,
+        name="Per-character files",
+        description="Export each crowd character as a separate file instead of one combined file"
     )

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -69,8 +69,10 @@ class OJ_PT_panel(bpy.types.Panel):
                         icon='CHECKMARK',
                     )
 
-            layout.prop(s, "packaging_mode")
+            layout.prop(s, "export_blend")
             layout.prop(s, "export_gltf")
+            if s.is_crowd:
+                layout.prop(s, "per_character_export")
             build_row = layout.row()
             build_row.enabled = s.has_plan and not s.built
             build_row.operator("open_jaywalker.build", icon='MOD_ARMATURE')
@@ -109,6 +111,15 @@ class OJ_PT_panel(bpy.types.Panel):
                                 warn_box.label(text="   - {0}".format(name))
                 else:
                     res_col.label(text="Build failed.", icon='ERROR')
+
+            layout.separator()
+            export_box = layout.box()
+            export_box.label(text="Export", icon='EXPORT')
+            if s.is_crowd:
+                export_box.prop(s, "per_character_export")
+            row = export_box.row(align=True)
+            row.operator("open_jaywalker.export_blend", icon='FILE_BLEND', text=".blend")
+            row.operator("open_jaywalker.export_gltf", icon='FILE_3D', text=".glb")
 
         if s.asset_dir:
             layout.separator()

--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -824,3 +824,90 @@ def export_generated_gltf(bpy_module, wrapper_collection_name: str, filepath: st
         export_format='GLB',
     )
     return filepath
+
+
+def export_crowd_characters_blend(bpy_module, wrapper_collection_name: str, output_dir: str) -> List[str]:
+    """Export each child collection of a crowd wrapper as a separate .blend file.
+
+    Iterates over wrapper.children (one per character) and writes each to
+    <output_dir>/blend/<character_id>.blend via bpy.data.libraries.write.
+    Returns the list of written file paths.
+
+    Raises ValueError if the wrapper is absent, not generated, or has no children.
+    """
+    wrapper = bpy_module.data.collections.get(wrapper_collection_name)
+    if wrapper is None or not bool(wrapper.get(GENERATED_MARKER_KEY)):
+        raise ValueError(
+            "Refusing to export '{0}': not a generated wrapper collection".format(
+                wrapper_collection_name
+            )
+        )
+    children = list(wrapper.children)
+    if not children:
+        raise ValueError(
+            "Wrapper '{0}' has no child collections to export individually".format(
+                wrapper_collection_name
+            )
+        )
+    blend_dir = os.path.join(output_dir, "blend")
+    os.makedirs(blend_dir, exist_ok=True)
+    exported = []
+    asset_name = wrapper.get(GENERATED_ASSET_KEY) or ""
+    prefix = "ASAM_{0}_".format(asset_name)
+    for child in children:
+        character_id = child.name
+        if character_id.startswith(prefix):
+            character_id = character_id[len(prefix):]
+        filepath = os.path.join(blend_dir, "{0}.blend".format(character_id))
+        bpy_module.data.libraries.write(filepath, {child}, fake_user=True)
+        exported.append(filepath)
+    return exported
+
+
+def export_crowd_characters_gltf(bpy_module, wrapper_collection_name: str, output_dir: str) -> List[str]:
+    """Export each child collection of a crowd wrapper as a separate .glb file.
+
+    Iterates over wrapper.children (one per character), selects its objects,
+    and exports to <output_dir>/glb/<character_id>.glb.
+    Returns the list of written file paths.
+
+    Raises ValueError if the wrapper is absent, not generated, or has no children.
+    """
+    wrapper = bpy_module.data.collections.get(wrapper_collection_name)
+    if wrapper is None or not bool(wrapper.get(GENERATED_MARKER_KEY)):
+        raise ValueError(
+            "Refusing to export '{0}': not a generated wrapper collection".format(
+                wrapper_collection_name
+            )
+        )
+    children = list(wrapper.children)
+    if not children:
+        raise ValueError(
+            "Wrapper '{0}' has no child collections to export individually".format(
+                wrapper_collection_name
+            )
+        )
+    glb_dir = os.path.join(output_dir, "glb")
+    os.makedirs(glb_dir, exist_ok=True)
+    exported = []
+    asset_name = wrapper.get(GENERATED_ASSET_KEY) or ""
+    prefix = "ASAM_{0}_".format(asset_name)
+    try:
+        bpy_module.ops.object.mode_set(mode="OBJECT")
+    except RuntimeError:
+        pass
+    for child in children:
+        character_id = child.name
+        if character_id.startswith(prefix):
+            character_id = character_id[len(prefix):]
+        filepath = os.path.join(glb_dir, "{0}.glb".format(character_id))
+        bpy_module.ops.object.select_all(action='DESELECT')
+        for obj in child.all_objects:
+            obj.select_set(True)
+        bpy_module.ops.export_scene.gltf(
+            filepath=filepath,
+            use_selection=True,
+            export_format='GLB',
+        )
+        exported.append(filepath)
+    return exported

--- a/src/asam_human_builder/build_runner.py
+++ b/src/asam_human_builder/build_runner.py
@@ -20,27 +20,22 @@ from asam_human_builder.builder import (
 from asam_human_builder.blender_builder import (
     build_armature_in_blender,
     build_crowd_in_blender,
+    export_crowd_characters_blend,
+    export_crowd_characters_gltf,
     export_generated_blend,
     export_generated_gltf,
     purge_previous_generated_artifacts,
 )
 
-# Output packaging modes. Shared canonical definition so the addon (Task C3) and the
-# builder reference the same literals instead of duplicating magic strings.
-PACKAGING_INPLACE_EXPORT = "inplace_export"
-PACKAGING_INPLACE_ONLY = "inplace_only"
-PACKAGING_SEPARATE_ONLY = "separate_only"
-PACKAGING_MODES = (PACKAGING_INPLACE_EXPORT, PACKAGING_INPLACE_ONLY, PACKAGING_SEPARATE_ONLY)
 
-
-def run_build(asset_dir, bpy, packaging_mode=PACKAGING_INPLACE_EXPORT, export_gltf=False) -> dict:
+def run_build(asset_dir, bpy, export_blend=False, export_gltf=True, per_character=False) -> dict:
     """Resolve specs for asset_dir and build them (single or crowd).
 
-    packaging_mode controls post-build export:
-      "inplace_export" (default): build in place, then export generated wrapper
-          collection to <asset_dir>/<asset_name>_asam.blend.
-      "inplace_only": build only, no export.
-      "separate_only": export, then purge generated data from the open file.
+    export_blend: export generated wrapper to <asset_dir>/<asset_name>_asam.blend.
+    export_gltf: export generated wrapper to <asset_dir>/<asset_name>_asam.glb.
+    per_character: when True and the build is a crowd, export each character
+        as a separate file under <asset_dir>/blend/ and/or <asset_dir>/glb/
+        instead of a single monolithic file.
 
     Export failures are recorded on the report and never abort the in-place build.
 
@@ -72,9 +67,13 @@ def run_build(asset_dir, bpy, packaging_mode=PACKAGING_INPLACE_EXPORT, export_gl
         print_builder_summary(report, report_path)
         wrapper_name = build_spec["generated_collection_name"]
 
-    _export_if_requested(asset_dir, resolved["asset_name"], wrapper_name, bpy, packaging_mode, export_gltf, report)
+    is_crowd = resolved["crowd"]
+    _export_if_requested(
+        asset_dir, resolved["asset_name"], wrapper_name, bpy,
+        export_blend, export_gltf, per_character, is_crowd, report,
+    )
 
-    if resolved["crowd"]:
+    if is_crowd:
         for char_report in report.get("characters", []):
             heuristics = char_report.get("targets_created_heuristically", [])
             if heuristics:
@@ -93,38 +92,47 @@ def run_build(asset_dir, bpy, packaging_mode=PACKAGING_INPLACE_EXPORT, export_gl
     return report
 
 
-def _export_if_requested(asset_dir, asset_name, wrapper_name, bpy, packaging_mode, export_gltf, report):
-    """Record packaging outcome on the report and export when requested.
+def _export_if_requested(
+    asset_dir, asset_name, wrapper_name, bpy,
+    export_blend, export_gltf, per_character, is_crowd, report,
+):
+    """Record export outcome on the report and export when requested.
 
-    Modes:
-      - PACKAGING_INPLACE_ONLY: no export, no purge.
-      - PACKAGING_INPLACE_EXPORT: write the generated wrapper to a clean .blend.
-      - PACKAGING_SEPARATE_ONLY: export, then purge generated data from the open file.
+    export_blend / export_gltf control which formats are exported.
+    per_character, when True for a crowd build, exports each character as a
+    separate file instead of one monolithic archive.
 
-    `packaging_mode` is always recorded (even for inplace_only) so the report shape is
-    consistent across modes. Export failures are caught and recorded; they never abort
-    the already-completed in-place build.
+    Export failures are caught and recorded; they never abort the
+    already-completed in-place build.
     """
-    report["packaging_mode"] = packaging_mode
+    report["export_blend"] = export_blend
     report["exported_blend_path"] = None
-    report["export_error"] = None
-    if packaging_mode == PACKAGING_INPLACE_ONLY:
-        return
-    out_path = str(Path(asset_dir) / "{0}_asam.blend".format(asset_name))
-    try:
-        report["exported_blend_path"] = export_generated_blend(bpy, wrapper_name, out_path)
-    except Exception as exc:  # never abort the already-completed in-place build
-        report["export_error"] = str(exc)
-        
+    report["exported_blend_paths"] = None
+    report["export_blend_error"] = None
+    if export_blend:
+        try:
+            if per_character and is_crowd:
+                report["exported_blend_paths"] = export_crowd_characters_blend(
+                    bpy, wrapper_name, str(asset_dir)
+                )
+            else:
+                out_path = str(Path(asset_dir) / "{0}_asam.blend".format(asset_name))
+                report["exported_blend_path"] = export_generated_blend(bpy, wrapper_name, out_path)
+        except Exception as exc:
+            report["export_blend_error"] = str(exc)
+
     report["export_gltf"] = export_gltf
     report["exported_gltf_path"] = None
+    report["exported_gltf_paths"] = None
     report["export_gltf_error"] = None
     if export_gltf:
-        out_gltf = str(Path(asset_dir) / "{0}_asam.glb".format(asset_name))
         try:
-            report["exported_gltf_path"] = export_generated_gltf(bpy, wrapper_name, out_gltf)
+            if per_character and is_crowd:
+                report["exported_gltf_paths"] = export_crowd_characters_gltf(
+                    bpy, wrapper_name, str(asset_dir)
+                )
+            else:
+                out_gltf = str(Path(asset_dir) / "{0}_asam.glb".format(asset_name))
+                report["exported_gltf_path"] = export_generated_gltf(bpy, wrapper_name, out_gltf)
         except Exception as exc:
             report["export_gltf_error"] = str(exc)
-            
-    if packaging_mode == PACKAGING_SEPARATE_ONLY:
-        purge_previous_generated_artifacts(bpy)

--- a/tests/test_addon_interface.py
+++ b/tests/test_addon_interface.py
@@ -124,8 +124,9 @@ class AddonInterfaceTests(unittest.TestCase):
             has_plan=True,
             built=False,
             asset_dir="/x",
-            packaging_mode="inplace_only",
-            export_gltf=False,
+            export_blend=False,
+            export_gltf=True,
+            per_character_export=False,
             build_succeeded=0,
             build_failed=0,
             failed_characters_csv="",
@@ -168,8 +169,9 @@ class AddonInterfaceTests(unittest.TestCase):
             has_plan=True,
             built=False,
             asset_dir="/x",
-            packaging_mode="inplace_only",
-            export_gltf=False,
+            export_blend=False,
+            export_gltf=True,
+            per_character_export=False,
             build_succeeded=0,
             build_failed=0,
             failed_characters_csv="",
@@ -221,8 +223,9 @@ class AddonInterfaceTests(unittest.TestCase):
             has_plan=True,
             built=False,
             asset_dir="/x",
-            packaging_mode="inplace_only",
-            export_gltf=False,
+            export_blend=False,
+            export_gltf=True,
+            per_character_export=False,
             build_succeeded=0,
             build_failed=0,
             failed_characters_csv="",
@@ -271,25 +274,25 @@ class AddonInterfaceTests(unittest.TestCase):
             def __init__(self):
                 self.alert = False
                 
-            def separator(self):
+            def separator(self, *args, **kwargs):
                 pass
                 
-            def label(self, text="", icon='NONE'):
+            def label(self, text="", icon='NONE', *args, **kwargs):
                 pass
                 
-            def operator(self, name, icon='NONE'):
+            def operator(self, name, icon='NONE', *args, **kwargs):
                 pass
                 
-            def prop(self, data, prop_name, text="", icon='NONE', emboss=True):
+            def prop(self, data, prop_name, text="", icon='NONE', emboss=True, *args, **kwargs):
                 pass
                 
-            def row(self):
+            def row(self, *args, **kwargs):
                 return MockLayout()
                 
-            def box(self):
+            def box(self, *args, **kwargs):
                 return MockLayout()
                 
-            def column(self, align=False):
+            def column(self, align=False, *args, **kwargs):
                 return MockLayout()
 
         mock_layout = MockLayout()
@@ -313,8 +316,9 @@ class AddonInterfaceTests(unittest.TestCase):
             character_ids_csv="",
             character_count=1,
             show_details=False,
-            packaging_mode="inplace_only",
-            export_gltf=False
+            export_blend=False,
+            export_gltf=True,
+            per_character_export=False
         )
         mock_context = types.SimpleNamespace(scene=types.SimpleNamespace(open_jaywalker=mock_settings))
         
@@ -336,25 +340,25 @@ class AddonInterfaceTests(unittest.TestCase):
                 self.labels = []
                 self.alert = False
                 
-            def separator(self):
+            def separator(self, *args, **kwargs):
                 pass
                 
-            def label(self, text="", icon='NONE'):
+            def label(self, text="", icon='NONE', *args, **kwargs):
                 self.labels.append((text, icon))
                 
-            def operator(self, name, icon='NONE'):
+            def operator(self, name, icon='NONE', *args, **kwargs):
                 pass
                 
-            def prop(self, data, prop_name, text="", icon='NONE', emboss=True):
+            def prop(self, data, prop_name, text="", icon='NONE', emboss=True, *args, **kwargs):
                 pass
                 
-            def row(self):
+            def row(self, *args, **kwargs):
                 return self
                 
-            def box(self):
+            def box(self, *args, **kwargs):
                 return self
                 
-            def column(self, align=False):
+            def column(self, align=False, *args, **kwargs):
                 return self
 
         mock_layout = MockLayout()
@@ -378,8 +382,9 @@ class AddonInterfaceTests(unittest.TestCase):
             character_ids_csv="",
             character_count=7,
             show_details=False,
-            packaging_mode="inplace_only",
-            export_gltf=False
+            export_blend=False,
+            export_gltf=True,
+            per_character_export=False
         )
         mock_context = types.SimpleNamespace(scene=types.SimpleNamespace(open_jaywalker=mock_settings))
         
@@ -463,25 +468,25 @@ class AddonInterfaceTests(unittest.TestCase):
             def __init__(self):
                 self.props_drawn = []
                 
-            def separator(self):
+            def separator(self, *args, **kwargs):
                 pass
                 
-            def label(self, text="", icon='NONE'):
+            def label(self, text="", icon='NONE', *args, **kwargs):
                 pass
                 
-            def operator(self, name, icon='NONE'):
+            def operator(self, name, icon='NONE', *args, **kwargs):
                 pass
                 
-            def prop(self, data, prop_name, text="", icon='NONE', emboss=True):
+            def prop(self, data, prop_name, text="", icon='NONE', emboss=True, *args, **kwargs):
                 self.props_drawn.append((data, prop_name))
                 
-            def row(self):
+            def row(self, *args, **kwargs):
                 return self
                 
-            def box(self):
+            def box(self, *args, **kwargs):
                 return self
                 
-            def column(self, align=False):
+            def column(self, align=False, *args, **kwargs):
                 return self
 
         mock_layout = MockLayout()
@@ -504,8 +509,9 @@ class AddonInterfaceTests(unittest.TestCase):
             character_ids_csv="",
             character_count=1,
             show_details=False,
-            packaging_mode="inplace_only",
-            export_gltf=False,
+            export_blend=False,
+            export_gltf=True,
+            per_character_export=False,
             show_generated_armature=True
         )
         ui_context = types.SimpleNamespace(scene=types.SimpleNamespace(open_jaywalker=ui_settings))

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -27,6 +27,8 @@ from asam_human_builder.builder import (  # noqa: E402
 )
 from asam_human_builder.blender_builder import (  # noqa: E402
     build_armature_in_blender,
+    export_crowd_characters_blend,
+    export_crowd_characters_gltf,
     export_generated_blend,
     purge_previous_generated_artifacts,
 )
@@ -2720,6 +2722,123 @@ class ExportGeneratedBlendTests(unittest.TestCase):
         fake_bpy = _FakeBpy()
         with self.assertRaises(ValueError):
             export_generated_blend(fake_bpy, "DoesNotExist", "/tmp/x.blend")
+
+
+class ExportCrowdCharactersBlendTests(unittest.TestCase):
+    def test_export_crowd_characters_blend_writes_children(self):
+        import tempfile
+        import os
+        fake_bpy = _FakeBpy()
+        wrapper = fake_bpy.data.collections.new("ASAM_crowd")
+        wrapper[GENERATED_MARKER_KEY] = True
+        wrapper[GENERATED_ASSET_KEY] = "crowd"
+
+        # Add child collections for individual characters
+        char0 = fake_bpy.data.collections.new("ASAM_crowd_char0")
+        char1 = fake_bpy.data.collections.new("ASAM_crowd_char1")
+        wrapper.children.link(char0)
+        wrapper.children.link(char1)
+
+        out_dir = tempfile.mkdtemp()
+        paths = export_crowd_characters_blend(fake_bpy, "ASAM_crowd", out_dir)
+        
+        # Returns list of written files
+        self.assertEqual(len(paths), 2)
+        # Verify prefix stripping logic: ASAM_crowd_char0 -> char0.blend
+        expected_char0 = os.path.join(out_dir, "blend", "char0.blend")
+        expected_char1 = os.path.join(out_dir, "blend", "char1.blend")
+        self.assertIn(expected_char0, paths)
+        self.assertIn(expected_char1, paths)
+        
+        # Check libraries.write calls
+        write_calls = fake_bpy.data.libraries.write_calls
+        self.assertEqual(len(write_calls), 2)
+        
+        # Verify that libraries.write was called with each character collection
+        written_datablocks = [list(call["datablocks"])[0] for call in write_calls]
+        self.assertIn(char0, written_datablocks)
+        self.assertIn(char1, written_datablocks)
+
+    def test_export_crowd_characters_blend_errors(self):
+        fake_bpy = _FakeBpy()
+        # Missing collection
+        with self.assertRaises(ValueError):
+            export_crowd_characters_blend(fake_bpy, "DoesNotExist", "/tmp")
+
+        # Not generated collection
+        wrapper = fake_bpy.data.collections.new("ASAM_crowd")
+        with self.assertRaises(ValueError):
+            export_crowd_characters_blend(fake_bpy, "ASAM_crowd", "/tmp")
+
+        # No children
+        wrapper[GENERATED_MARKER_KEY] = True
+        with self.assertRaises(ValueError):
+            export_crowd_characters_blend(fake_bpy, "ASAM_crowd", "/tmp")
+
+
+class ExportCrowdCharactersGltfTests(unittest.TestCase):
+    def test_export_crowd_characters_gltf_exports_children(self):
+        import tempfile
+        import os
+        fake_bpy = _FakeBpy()
+        # Set up mock gltf operator
+        class _FakeExportSceneOps:
+            def __init__(self):
+                self.calls = []
+            def gltf(self, filepath, use_selection=False, export_format='GLB', **kwargs):
+                self.calls.append({
+                    "filepath": filepath,
+                    "use_selection": use_selection,
+                    "export_format": export_format,
+                })
+        fake_bpy.ops.export_scene = _FakeExportSceneOps()
+
+        wrapper = fake_bpy.data.collections.new("ASAM_crowd")
+        wrapper[GENERATED_MARKER_KEY] = True
+        wrapper[GENERATED_ASSET_KEY] = "crowd"
+
+        char0 = fake_bpy.data.collections.new("ASAM_crowd_char0")
+        char1 = fake_bpy.data.collections.new("ASAM_crowd_char1")
+        wrapper.children.link(char0)
+        wrapper.children.link(char1)
+
+        # Add some mock objects to the character collections so they can be selected
+        obj0 = _FakeObject("char0_mesh")
+        obj1 = _FakeObject("char1_mesh")
+        char0.objects.link(obj0)
+        char1.objects.link(obj1)
+
+        out_dir = tempfile.mkdtemp()
+        paths = export_crowd_characters_gltf(fake_bpy, "ASAM_crowd", out_dir)
+
+        self.assertEqual(len(paths), 2)
+        expected_char0 = os.path.join(out_dir, "glb", "char0.glb")
+        expected_char1 = os.path.join(out_dir, "glb", "char1.glb")
+        self.assertIn(expected_char0, paths)
+        self.assertIn(expected_char1, paths)
+
+        # Check gltf calls
+        calls = fake_bpy.ops.export_scene.calls
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0]["filepath"], expected_char0)
+        self.assertTrue(calls[0]["use_selection"])
+        self.assertEqual(calls[0]["export_format"], "GLB")
+
+    def test_export_crowd_characters_gltf_errors(self):
+        fake_bpy = _FakeBpy()
+        # Missing collection
+        with self.assertRaises(ValueError):
+            export_crowd_characters_gltf(fake_bpy, "DoesNotExist", "/tmp")
+
+        # Not generated collection
+        wrapper = fake_bpy.data.collections.new("ASAM_crowd")
+        with self.assertRaises(ValueError):
+            export_crowd_characters_gltf(fake_bpy, "ASAM_crowd", "/tmp")
+
+        # No children
+        wrapper[GENERATED_MARKER_KEY] = True
+        with self.assertRaises(ValueError):
+            export_crowd_characters_gltf(fake_bpy, "ASAM_crowd", "/tmp")
 
 
 class PlacementDeltaTests(unittest.TestCase):

--- a/tests/test_build_runner.py
+++ b/tests/test_build_runner.py
@@ -19,20 +19,14 @@ class RunBuildTests(unittest.TestCase):
              mock.patch.object(build_runner, "build_armature_in_blender", return_value={"exec": True}) as build_one, \
              mock.patch.object(build_runner, "write_builder_report", return_value=({"asset_name": "A"}, Path("/x/builder_report.json"))), \
              mock.patch.object(build_runner, "print_builder_summary"):
-            report = build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
+            report = build_runner.run_build(Path("/x"), bpy="BPY", export_blend=False, export_gltf=False)
 
         build_one.assert_called_once_with(spec, "BPY")
-        # inplace_only performs no export but still records the packaging mode for a
-        # consistent report shape across modes.
-        self.assertEqual(
-            report,
-            {
-                "asset_name": "A",
-                "packaging_mode": "inplace_only",
-                "exported_blend_path": None,
-                "export_error": None,
-            },
-        )
+        # No export requested: report records the flags with None paths.
+        self.assertEqual(report["export_blend"], False)
+        self.assertEqual(report["export_gltf"], False)
+        self.assertIsNone(report["exported_blend_path"])
+        self.assertIsNone(report["exported_gltf_path"])
 
     def test_crowd_dispatch(self):
         resolved = {
@@ -47,13 +41,13 @@ class RunBuildTests(unittest.TestCase):
              mock.patch.object(build_runner, "build_crowd_in_blender", return_value={"exec": True}) as build_crowd, \
              mock.patch.object(build_runner, "build_crowd_builder_report", return_value=crowd_report), \
              mock.patch.object(build_runner, "write_crowd_builder_report", return_value=(crowd_report, Path("/x/builder_report.json"))):
-            report = build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
+            report = build_runner.run_build(Path("/x"), bpy="BPY", export_blend=False, export_gltf=False)
 
         build_crowd.assert_called_once_with("Crowd", "Crowd_Humans", [("c0", "SPEC0")], {"source_armature": "Root"}, "BPY")
         self.assertEqual(report, crowd_report)
 
 
-class RunBuildPackagingTests(unittest.TestCase):
+class RunBuildExportTests(unittest.TestCase):
     def _patch_single(self):
         return [
             mock.patch.object(build_runner, "build_character_specs_from_asset_dir",
@@ -65,43 +59,134 @@ class RunBuildPackagingTests(unittest.TestCase):
             mock.patch.object(build_runner, "print_builder_summary"),
         ]
 
-    def test_inplace_export_calls_export(self):
+    def test_export_blend_calls_export(self):
         for p in self._patch_single():
             p.start(); self.addCleanup(p.stop)
-        with mock.patch.object(build_runner, "export_generated_blend", return_value="/x/A_asam.blend") as export, \
-             mock.patch.object(build_runner, "purge_previous_generated_artifacts") as purge:
-            report = build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_export")
+        with mock.patch.object(build_runner, "export_generated_blend", return_value="/x/A_asam.blend") as export:
+            report = build_runner.run_build(Path("/x"), bpy="BPY", export_blend=True, export_gltf=False)
             export.assert_called_once()
-            purge.assert_not_called()
-            self.assertEqual(report["packaging_mode"], "inplace_export")
+            self.assertTrue(report["export_blend"])
             self.assertEqual(report["exported_blend_path"], "/x/A_asam.blend")
-            self.assertIsNone(report["export_error"])
+            self.assertIsNone(report["export_blend_error"])
 
-    def test_inplace_only_skips_export(self):
+    def test_export_gltf_calls_export(self):
         for p in self._patch_single():
             p.start(); self.addCleanup(p.stop)
-        with mock.patch.object(build_runner, "export_generated_blend") as export:
-            report = build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
-            export.assert_not_called()
-            # packaging_mode is recorded even when no export happens (consistent report shape).
-            self.assertEqual(report["packaging_mode"], "inplace_only")
+        with mock.patch.object(build_runner, "export_generated_gltf", return_value="/x/A_asam.glb") as export:
+            report = build_runner.run_build(Path("/x"), bpy="BPY", export_blend=False, export_gltf=True)
+            export.assert_called_once()
+            self.assertTrue(report["export_gltf"])
+            self.assertEqual(report["exported_gltf_path"], "/x/A_asam.glb")
+            self.assertIsNone(report["export_gltf_error"])
+
+    def test_no_export_skips_both(self):
+        for p in self._patch_single():
+            p.start(); self.addCleanup(p.stop)
+        with mock.patch.object(build_runner, "export_generated_blend") as blend_export, \
+             mock.patch.object(build_runner, "export_generated_gltf") as gltf_export:
+            report = build_runner.run_build(Path("/x"), bpy="BPY", export_blend=False, export_gltf=False)
+            blend_export.assert_not_called()
+            gltf_export.assert_not_called()
+            self.assertFalse(report["export_blend"])
+            self.assertFalse(report["export_gltf"])
             self.assertIsNone(report["exported_blend_path"])
+            self.assertIsNone(report["exported_gltf_path"])
 
-    def test_separate_only_exports_then_purges(self):
-        for p in self._patch_single():
-            p.start(); self.addCleanup(p.stop)
-        with mock.patch.object(build_runner, "export_generated_blend", return_value="/x/A_asam.blend"), \
-             mock.patch.object(build_runner, "purge_previous_generated_artifacts") as purge:
-            build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="separate_only")
-            purge.assert_called_once()
-
-    def test_export_failure_does_not_abort(self):
+    def test_export_blend_failure_does_not_abort(self):
         for p in self._patch_single():
             p.start(); self.addCleanup(p.stop)
         with mock.patch.object(build_runner, "export_generated_blend", side_effect=RuntimeError("disk full")):
-            report = build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_export")
-            self.assertEqual(report.get("exported_blend_path"), None)
-            self.assertIn("export_error", report)
+            report = build_runner.run_build(Path("/x"), bpy="BPY", export_blend=True, export_gltf=False)
+            self.assertIsNone(report["exported_blend_path"])
+            self.assertEqual(report["export_blend_error"], "disk full")
+
+    def test_export_gltf_failure_does_not_abort(self):
+        for p in self._patch_single():
+            p.start(); self.addCleanup(p.stop)
+        with mock.patch.object(build_runner, "export_generated_gltf", side_effect=RuntimeError("glTF error")):
+            report = build_runner.run_build(Path("/x"), bpy="BPY", export_blend=False, export_gltf=True)
+            self.assertIsNone(report["exported_gltf_path"])
+            self.assertEqual(report["export_gltf_error"], "glTF error")
+
+    def test_default_exports_gltf_not_blend(self):
+        """Verify the new defaults: export_gltf=True, export_blend=False."""
+        for p in self._patch_single():
+            p.start(); self.addCleanup(p.stop)
+        with mock.patch.object(build_runner, "export_generated_gltf", return_value="/x/A_asam.glb") as gltf_export, \
+             mock.patch.object(build_runner, "export_generated_blend") as blend_export:
+            report = build_runner.run_build(Path("/x"), bpy="BPY")
+            gltf_export.assert_called_once()
+            blend_export.assert_not_called()
+            self.assertTrue(report["export_gltf"])
+            self.assertFalse(report["export_blend"])
+
+
+class RunBuildPerCharacterExportTests(unittest.TestCase):
+    def _patch_crowd(self):
+        return [
+            mock.patch.object(build_runner, "build_character_specs_from_asset_dir",
+                              return_value={"crowd": True, "asset_name": "Crowd",
+                                            "wrapper_collection_name": "ASAM_Crowd",
+                                            "decomposition": {"source_armature": "Root"},
+                                            "character_specs": [("c0", "S0"), ("c1", "S1")]}),
+            mock.patch.object(build_runner, "build_crowd_in_blender", return_value={"exec": True}),
+            mock.patch.object(build_runner, "build_crowd_builder_report",
+                              return_value={"characters": [{"character_id": "c0"}, {"character_id": "c1"}],
+                                            "failed_characters": []}),
+            mock.patch.object(build_runner, "write_crowd_builder_report",
+                              return_value=({"characters": [{"character_id": "c0"}, {"character_id": "c1"}],
+                                             "failed_characters": []},
+                                            Path("/x/builder_report.json"))),
+        ]
+
+    def test_per_character_blend_calls_crowd_function(self):
+        for p in self._patch_crowd():
+            p.start(); self.addCleanup(p.stop)
+        with mock.patch.object(build_runner, "export_crowd_characters_blend",
+                               return_value=["/x/blend/c0.blend", "/x/blend/c1.blend"]) as crowd_blend, \
+             mock.patch.object(build_runner, "export_generated_blend") as single_blend:
+            report = build_runner.run_build(
+                Path("/x"), bpy="BPY", export_blend=True, export_gltf=False, per_character=True
+            )
+            crowd_blend.assert_called_once()
+            single_blend.assert_not_called()
+            self.assertEqual(report["exported_blend_paths"], ["/x/blend/c0.blend", "/x/blend/c1.blend"])
+            self.assertIsNone(report["exported_blend_path"])
+
+    def test_per_character_gltf_calls_crowd_function(self):
+        for p in self._patch_crowd():
+            p.start(); self.addCleanup(p.stop)
+        with mock.patch.object(build_runner, "export_crowd_characters_gltf",
+                               return_value=["/x/glb/c0.glb", "/x/glb/c1.glb"]) as crowd_gltf, \
+             mock.patch.object(build_runner, "export_generated_gltf") as single_gltf:
+            report = build_runner.run_build(
+                Path("/x"), bpy="BPY", export_blend=False, export_gltf=True, per_character=True
+            )
+            crowd_gltf.assert_called_once()
+            single_gltf.assert_not_called()
+            self.assertEqual(report["exported_gltf_paths"], ["/x/glb/c0.glb", "/x/glb/c1.glb"])
+            self.assertIsNone(report["exported_gltf_path"])
+
+    def test_per_character_on_single_asset_uses_monolithic(self):
+        """per_character=True on a non-crowd asset falls back to monolithic export."""
+        patches = [
+            mock.patch.object(build_runner, "build_character_specs_from_asset_dir",
+                              return_value={"crowd": False, "asset_name": "A",
+                                            "specs": [{"generated_collection_name": "ASAM_A"}]}),
+            mock.patch.object(build_runner, "build_armature_in_blender", return_value={"exec": True}),
+            mock.patch.object(build_runner, "write_builder_report",
+                              return_value=({"asset_name": "A"}, Path("/x/builder_report.json"))),
+            mock.patch.object(build_runner, "print_builder_summary"),
+        ]
+        for p in patches:
+            p.start(); self.addCleanup(p.stop)
+        with mock.patch.object(build_runner, "export_generated_gltf", return_value="/x/A_asam.glb") as single_gltf, \
+             mock.patch.object(build_runner, "export_crowd_characters_gltf") as crowd_gltf:
+            report = build_runner.run_build(
+                Path("/x"), bpy="BPY", export_blend=False, export_gltf=True, per_character=True
+            )
+            single_gltf.assert_called_once()
+            crowd_gltf.assert_not_called()
 
 
 class RunBuildWarningTests(unittest.TestCase):
@@ -120,7 +205,7 @@ class RunBuildWarningTests(unittest.TestCase):
                  mock.patch.object(build_runner, "build_armature_in_blender", return_value={"exec": True}), \
                  mock.patch.object(build_runner, "write_builder_report", return_value=(report_data, Path("/x/builder_report.json"))), \
                  mock.patch.object(build_runner, "print_builder_summary"):
-                build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
+                build_runner.run_build(Path("/x"), bpy="BPY", export_blend=False, export_gltf=False)
                 
         output = f.getvalue()
         self.assertIn("WARNING: Synthesized inert bones added for compliance: Full_Fingers_Left, Full_Fingers_Right", output)
@@ -154,7 +239,7 @@ class RunBuildWarningTests(unittest.TestCase):
                  mock.patch.object(build_runner, "build_crowd_in_blender", return_value={"exec": True}), \
                  mock.patch.object(build_runner, "build_crowd_builder_report", return_value=crowd_report), \
                  mock.patch.object(build_runner, "write_crowd_builder_report", return_value=(crowd_report, Path("/x/builder_report.json"))):
-                build_runner.run_build(Path("/x"), bpy="BPY", packaging_mode="inplace_only")
+                build_runner.run_build(Path("/x"), bpy="BPY", export_blend=False, export_gltf=False)
                 
         output = f.getvalue()
         self.assertIn("WARNING: Character 'c0' has synthesized inert bones added for compliance: Full_Fingers_Left", output)


### PR DESCRIPTION
This PR implements a unified export strategy for single and crowd rigs, addressing the requirements in #71 and #79.

### Key Changes
- **Core Library (`blender_builder.py`, `build_runner.py`)**:
  - Replaced the implicit, destructive `packaging_mode` parameter and the `separate_only` mode with explicit, toggleable export options (`export_blend`, `export_gltf`, `per_character`).
  - Added `export_crowd_characters_blend` and `export_crowd_characters_gltf` functions to support individual character exports for crowd assets.
- **Addon UI & Settings (`state.py`, `ui.py`, `operators.py`, `__init__.py`)**:
  - Replaced the pre-build EnumProperty list with toggle checkboxes for "Auto-export .blend", "Auto-export .glb", and "Per-character files" (visible for crowds).
  - Created a new post-build **Export** section inside the UI panel allowing manual, on-demand exports to `.blend` or `.glb` formats.
  - Implemented and registered manual export operators (`open_jaywalker.export_blend` and `open_jaywalker.export_gltf`).
- **Tests**:
  - Added unit tests for the new crowd character export functions (`ExportCrowdCharactersBlendTests`, `ExportCrowdCharactersGltfTests` in `test_asam_human_builder.py`).
  - Updated mock settings and integration tests in `test_build_runner.py` and `test_addon_interface.py`.
  - Robustified `MockLayout` mock implementations to support arbitrary kwargs (`align`, `text`) for UI layout rendering.

Closes #71
Closes #79
