### PR TITLE
Preserve extra bones in ASAM builder spec

### DIFF
--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -657,6 +657,36 @@ def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones:
                 "parent": "Hip",
             }
         )
+    # Build lookup map: source_bone_name -> final_bone_name
+    source_to_final_name = {}
+    for bone in spec["bones"]:
+        src_name = bone.get("source_bone")
+        if src_name:
+            source_to_final_name[src_name] = bone["name"]
+    for extra in spec["extras_preserved"]:
+        extra_name = extra.get("bone_name")
+        if extra_name:
+            source_to_final_name[extra_name] = extra_name
+
+    for extra in spec["extras_preserved"]:
+        extra_name = extra.get("bone_name")
+        if not extra_name or extra_name not in source_bones:
+            continue
+        geom = source_bones[extra_name]
+        parent_name = geom.get("parent")
+        final_parent = source_to_final_name.get(parent_name) if parent_name else None
+        spec["bones"].append(
+            {
+                "name": extra_name,
+                "parent_bone": final_parent,
+                "head": _to_grp_root_local(geom["head"], grp_root_local_origin),
+                "tail": _to_grp_root_local(geom["tail"], grp_root_local_origin),
+                "use_connect": False,
+                "geometry_source": "source_bone",
+                "source_bone": extra_name,
+                "semantic_action": "preserve_extra",
+            }
+        )
 
     return spec
 

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -892,6 +892,13 @@ class AsamHumanBuilderTests(unittest.TestCase):
             [],
         )
 
+        # Verify that preserved extra bones are added to build_spec["bones"]
+        extra_bones = [bone for bone in build_spec["bones"] if bone.get("semantic_action") == "preserve_extra"]
+        self.assertGreater(len(extra_bones), 0)
+        hair_bone = _spec_bone(build_spec, "Hair_Front")
+        self.assertEqual(hair_bone["parent_bone"], "DEF-spine.006")
+        self.assertEqual(hair_bone["semantic_action"], "preserve_extra")
+
         root_bone = _spec_bone(build_spec, "Root")
         self.assertEqual(root_bone["geometry_source"], "root_resolution")
         self.assertEqual(root_bone["source_bone"], "root")
@@ -3554,6 +3561,40 @@ class EyeFingerDispatchTests(unittest.TestCase):
         )
         self.assertEqual(source, "source_bone")   # direct map, not eye_anchored
         self.assertEqual(bone, "L_eye")
+
+    def test_build_armature_spec_preserves_extras(self):
+        from asam_human_builder.builder import build_armature_spec
+        report = _base_classifier_report()
+        plan = _base_build_plan()
+        
+        # Add an extra bone in extras_preserved
+        plan["extras_preserved"] = [
+            {"bone_name": "DEF-hair", "reason": "named_extra", "origin": "primary", "role": "deform"}
+        ]
+        
+        # Lower_Arm_Left is mapped to DEF-forearm.L
+        report["semantic_mapping"]["Lower_Arm_Left"]["action"] = "direct_map"
+        report["semantic_mapping"]["Lower_Arm_Left"]["source_bone"] = "DEF-forearm.L"
+        
+        # Set up source bones: DEF-hair has parent DEF-forearm.L
+        source_bones = {
+            "DEF-forearm.L": _bone("DEF-forearm.L", "DEF-upper_arm.L", (0.0, 0.0, 1.0), (0.0, 0.0, 1.5)),
+            "DEF-hair": _bone("DEF-hair", "DEF-forearm.L", (0.0, 0.0, 1.5), (0.0, 0.0, 2.0)),
+        }
+        
+        spec = build_armature_spec(report, plan, source_bones)
+        
+        # Verify extras_preserved contains DEF-hair
+        self.assertEqual(len(spec["extras_preserved"]), 1)
+        self.assertEqual(spec["extras_preserved"][0]["bone_name"], "DEF-hair")
+        
+        # Verify the bone was added to spec["bones"]
+        extra_bone = next((b for b in spec["bones"] if b["name"] == "DEF-hair"), None)
+        self.assertIsNotNone(extra_bone)
+        self.assertEqual(extra_bone["source_bone"], "DEF-hair")
+        self.assertEqual(extra_bone["parent_bone"], "Lower_Arm_Left")  # Resolved parent to mapped target name
+        self.assertEqual(extra_bone["semantic_action"], "preserve_extra")
+        self.assertEqual(extra_bone["geometry_source"], "source_bone")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request addresses the issue where extra bones (such as hair, clothes, and items) are successfully identified as `extras_preserved` by the classifier, but are silently omitted during spec generation in `builder.py`. Because they were missing from the spec's bones list, `blender_builder.py` did not instantiate them, and subsequently purged their corresponding vertex groups on duplicated meshes.

### Changes
- Updated `build_armature_spec` in `src/asam_human_builder/builder.py` to iterate through `build_plan["extras_preserved"]`.
- Added a lookup dictionary `source_to_final_name` mapping source bone names to their target names in the generated armature.
- Resolved each extra bone's parent utilizing the lookup dictionary. If the parent exists in the source rig and was mapped to a core target, preserved pelvis pair, or is another preserved extra bone, it is correctly assigned as `parent_bone` in the final armature. Otherwise, it defaults to `None`.
- Rebased head and tail coordinates of extra bones to the Grp_Root-local space using `_to_grp_root_local`.
- Added unit tests in `tests/test_asam_human_builder.py` (both mock-based and extending the realistic `LowPolyCharacter4` fixture test) to ensure extra bones are properly generated and parented.

Closes #68
