### PR TITLE
Implement cleanable pipeline outputs and collapsible UI logs

### DIFF
--- a/addon/__init__.py
+++ b/addon/__init__.py
@@ -25,6 +25,7 @@ if os.path.exists(_SRC_DIR) and _SRC_DIR not in sys.path:
 
 import bpy
 
+from bpy.app.handlers import persistent
 from . import state
 from . import prefs
 from . import operators
@@ -40,8 +41,39 @@ _CLASSES = (
     operators.OJ_OT_export_gltf,
     operators.OJ_OT_open_output,
     operators.OJ_OT_clean,
+    operators.OJ_OT_reset_pipeline,
     ui.OJ_PT_panel,
 )
+
+
+@persistent
+def load_post_handler(dummy1, dummy2=None):
+    # Reset all settings properties to clean start
+    import bpy
+    scene = getattr(bpy.context, "scene", None)
+    if scene is not None:
+        s = getattr(scene, "open_jaywalker", None)
+        if s is not None:
+            s.has_plan = False
+            s.built = False
+            s.show_details = False
+            s.asset_dir = ""
+            s.recommended_armature = ""
+            s.mapped = 0
+            s.total = 28
+            s.missing_csv = ""
+            s.missing_by_target_csv = ""
+            s.review_flags_csv = ""
+            s.character_ids_csv = ""
+            s.is_crowd = False
+            s.character_count = 0
+            s.build_succeeded = 0
+            s.build_failed = 0
+            s.failed_characters_csv = ""
+            s.synthesized_bones_csv = ""
+            s.synthesized_bones_by_character_csv = ""
+            s.show_failed_details = False
+            s.show_inert_details = False
 
 
 def register():
@@ -54,10 +86,17 @@ def register():
         bpy.utils.register_class(cls)
     bpy.types.Scene.open_jaywalker = bpy.props.PointerProperty(type=state.OJSettings)
 
+    if load_post_handler not in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.append(load_post_handler)
+
 
 def unregister():
     addon_updater_ops.unregister()
     del bpy.types.Scene.open_jaywalker
+
+    if load_post_handler in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.remove(load_post_handler)
+
     for cls in reversed(_CLASSES):
         bpy.utils.unregister_class(cls)
 

--- a/addon/operators.py
+++ b/addon/operators.py
@@ -273,3 +273,48 @@ class OJ_OT_clean(bpy.types.Operator):
         s.show_generated_armature = True
         self.report({'INFO'}, "Removed {0} generated object(s)/collection(s).".format(removed))
         return {'FINISHED'}
+
+
+class OJ_OT_reset_pipeline(bpy.types.Operator):
+    bl_idname = "open_jaywalker.reset_pipeline"
+    bl_label = "Reset pipeline"
+    bl_description = "Clear all pipeline settings, generated reports on disk, and clean rigs/collections"
+
+    def execute(self, context):
+        purge_previous_generated_artifacts(bpy)
+        s = context.scene.open_jaywalker
+        
+        if s.asset_dir:
+            path = Path(s.asset_dir)
+            if path.exists() and path.is_dir():
+                for filename in ["classifier_report.json", "build_plan.json", "builder_report.json"]:
+                    file_path = path / filename
+                    if file_path.exists():
+                        try:
+                            file_path.unlink()
+                        except Exception:
+                            pass
+                            
+        s.has_plan = False
+        s.built = False
+        s.show_details = False
+        s.asset_dir = ""
+        s.recommended_armature = ""
+        s.mapped = 0
+        s.total = 28
+        s.missing_csv = ""
+        s.missing_by_target_csv = ""
+        s.review_flags_csv = ""
+        s.character_ids_csv = ""
+        s.is_crowd = False
+        s.character_count = 0
+        s.build_succeeded = 0
+        s.build_failed = 0
+        s.failed_characters_csv = ""
+        s.synthesized_bones_csv = ""
+        s.synthesized_bones_by_character_csv = ""
+        s.show_failed_details = False
+        s.show_inert_details = False
+        
+        self.report({'INFO'}, "Pipeline reset: rigs purged, reports cleared, state reset.")
+        return {'FINISHED'}

--- a/addon/state.py
+++ b/addon/state.py
@@ -76,3 +76,5 @@ class OJSettings(bpy.types.PropertyGroup):
         name="Per-character files",
         description="Export each crowd character as a separate file instead of one combined file"
     )
+    show_failed_details: bpy.props.BoolProperty(default=False)
+    show_inert_details: bpy.props.BoolProperty(default=False)

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -87,28 +87,49 @@ class OJ_PT_panel(bpy.types.Panel):
                 res_col.label(text="Succeeded: {0}".format(s.build_succeeded), icon='CHECKMARK')
                 if s.build_failed > 0:
                     res_col.label(text="Failed: {0}".format(s.build_failed), icon='ERROR')
-                    det = res_box.box()
-                    det.label(text="Failed characters:")
-                    for cid in s.failed_characters_csv.split(", "):
-                        if cid:
-                            det.label(text="   - {0}".format(cid))
+                    res_box.prop(
+                        s, "show_failed_details",
+                        text="Failed Details",
+                        icon=('TRIA_DOWN' if s.show_failed_details else 'TRIA_RIGHT'),
+                        emboss=False,
+                    )
+                    if s.show_failed_details:
+                        det = res_box.box()
+                        det.label(text="Failed characters:")
+                        for cid in s.failed_characters_csv.split(", "):
+                            if cid:
+                                det.label(text="   - {0}".format(cid))
                 if s.synthesized_bones_by_character_csv:
-                    warn_box = res_box.box()
-                    warn_box.alert = True
-                    warn_box.label(text="Synthesized Inert Bones (unbound):", icon='WARNING')
-                    for line in s.synthesized_bones_by_character_csv.split(" | "):
-                        if line:
-                            warn_box.label(text="   {0}".format(line))
+                    res_box.prop(
+                        s, "show_inert_details",
+                        text="Inert Bone Details",
+                        icon=('TRIA_DOWN' if s.show_inert_details else 'TRIA_RIGHT'),
+                        emboss=False,
+                    )
+                    if s.show_inert_details:
+                        warn_box = res_box.box()
+                        warn_box.alert = True
+                        warn_box.label(text="Synthesized Inert Bones (unbound):", icon='WARNING')
+                        for line in s.synthesized_bones_by_character_csv.split(" | "):
+                            if line:
+                                warn_box.label(text="   {0}".format(line))
             else:
                 if s.build_succeeded > 0:
                     res_col.label(text="Successfully built character.", icon='CHECKMARK')
                     if s.synthesized_bones_csv:
-                        warn_box = res_box.box()
-                        warn_box.alert = True
-                        warn_box.label(text="Synthesized Inert Bones (unbound):", icon='WARNING')
-                        for name in s.synthesized_bones_csv.split(", "):
-                            if name:
-                                warn_box.label(text="   - {0}".format(name))
+                        res_box.prop(
+                            s, "show_inert_details",
+                            text="Inert Bone Details",
+                            icon=('TRIA_DOWN' if s.show_inert_details else 'TRIA_RIGHT'),
+                            emboss=False,
+                        )
+                        if s.show_inert_details:
+                            warn_box = res_box.box()
+                            warn_box.alert = True
+                            warn_box.label(text="Synthesized Inert Bones (unbound):", icon='WARNING')
+                            for name in s.synthesized_bones_csv.split(", "):
+                                if name:
+                                    warn_box.label(text="   - {0}".format(name))
                 else:
                     res_col.label(text="Build failed.", icon='ERROR')
 
@@ -130,4 +151,5 @@ class OJ_PT_panel(bpy.types.Panel):
             layout.label(text="Run the pipeline to generate a plan.")
 
         layout.separator()
+        layout.operator("open_jaywalker.reset_pipeline", icon='LOOP_BACK')
         layout.operator("open_jaywalker.clean", icon='TRASH')

--- a/tests/test_addon_interface.py
+++ b/tests/test_addon_interface.py
@@ -20,6 +20,7 @@ class AddonInterfaceTests(unittest.TestCase):
         self.fake_bpy.app = types.ModuleType("bpy.app")
         self.fake_bpy.app.handlers = types.ModuleType("bpy.app.handlers")
         self.fake_bpy.app.handlers.persistent = lambda x: x  # decorator mock
+        self.fake_bpy.app.handlers.load_post = []
         
         self.fake_bpy.types = types.SimpleNamespace(
             Operator=object,
@@ -318,7 +319,9 @@ class AddonInterfaceTests(unittest.TestCase):
             show_details=False,
             export_blend=False,
             export_gltf=True,
-            per_character_export=False
+            per_character_export=False,
+            show_failed_details=True,
+            show_inert_details=True
         )
         mock_context = types.SimpleNamespace(scene=types.SimpleNamespace(open_jaywalker=mock_settings))
         
@@ -384,7 +387,9 @@ class AddonInterfaceTests(unittest.TestCase):
             show_details=False,
             export_blend=False,
             export_gltf=True,
-            per_character_export=False
+            per_character_export=False,
+            show_failed_details=True,
+            show_inert_details=True
         )
         mock_context = types.SimpleNamespace(scene=types.SimpleNamespace(open_jaywalker=mock_settings))
         
@@ -512,7 +517,9 @@ class AddonInterfaceTests(unittest.TestCase):
             export_blend=False,
             export_gltf=True,
             per_character_export=False,
-            show_generated_armature=True
+            show_generated_armature=True,
+            show_failed_details=False,
+            show_inert_details=False
         )
         ui_context = types.SimpleNamespace(scene=types.SimpleNamespace(open_jaywalker=ui_settings))
         
@@ -521,6 +528,231 @@ class AddonInterfaceTests(unittest.TestCase):
         panel.draw(ui_context)
         
         self.assertIn((ui_settings, "show_generated_armature"), mock_layout.props_drawn)
+
+    def test_reset_pipeline_operator(self):
+        import tempfile
+        import shutil
+        
+        # Create a temp directory for mock assets
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+        
+        mock_settings = types.SimpleNamespace(
+            has_plan=True,
+            built=True,
+            show_details=True,
+            asset_dir=temp_dir,
+            recommended_armature="Rig",
+            mapped=15,
+            total=28,
+            missing_csv="some_missing",
+            missing_by_target_csv="some_target",
+            review_flags_csv="flags",
+            character_ids_csv="ids",
+            is_crowd=True,
+            character_count=5,
+            build_succeeded=4,
+            build_failed=1,
+            failed_characters_csv="char1",
+            synthesized_bones_csv="bone1",
+            synthesized_bones_by_character_csv="char1 (bone1)",
+            show_failed_details=True,
+            show_inert_details=True
+        )
+        mock_context = types.SimpleNamespace(
+            scene=types.SimpleNamespace(open_jaywalker=mock_settings)
+        )
+        
+        # Create dummy report files in asset_dir
+        reports = ["classifier_report.json", "build_plan.json", "builder_report.json"]
+        for report in reports:
+            with open(Path(temp_dir) / report, "w") as f:
+                f.write("{}")
+                
+        # Verify files exist
+        for report in reports:
+            self.assertTrue((Path(temp_dir) / report).exists())
+            
+        with mock.patch("addon.operators.purge_previous_generated_artifacts") as mock_purge:
+            reset_op = self.operators.OJ_OT_reset_pipeline()
+            reset_op.report = mock.Mock()
+            res = reset_op.execute(mock_context)
+            
+            self.assertEqual(res, {'FINISHED'})
+            mock_purge.assert_called_once()
+            
+        # Verify files are deleted
+        for report in reports:
+            self.assertFalse((Path(temp_dir) / report).exists())
+            
+        # Verify state properties are reset to default values
+        self.assertFalse(mock_settings.has_plan)
+        self.assertFalse(mock_settings.built)
+        self.assertFalse(mock_settings.show_details)
+        self.assertEqual(mock_settings.asset_dir, "")
+        self.assertEqual(mock_settings.recommended_armature, "")
+        self.assertEqual(mock_settings.mapped, 0)
+        self.assertEqual(mock_settings.total, 28)
+        self.assertEqual(mock_settings.missing_csv, "")
+        self.assertEqual(mock_settings.missing_by_target_csv, "")
+        self.assertEqual(mock_settings.review_flags_csv, "")
+        self.assertEqual(mock_settings.character_ids_csv, "")
+        self.assertFalse(mock_settings.is_crowd)
+        self.assertEqual(mock_settings.character_count, 0)
+        self.assertEqual(mock_settings.build_succeeded, 0)
+        self.assertEqual(mock_settings.build_failed, 0)
+        self.assertEqual(mock_settings.failed_characters_csv, "")
+        self.assertEqual(mock_settings.synthesized_bones_csv, "")
+        self.assertEqual(mock_settings.synthesized_bones_by_character_csv, "")
+        self.assertFalse(mock_settings.show_failed_details)
+        self.assertFalse(mock_settings.show_inert_details)
+
+    def test_load_post_handler_resets_properties(self):
+        # We need to test the load_post_handler defined in addon.__init__
+        if "addon" in sys.modules:
+            del sys.modules["addon"]
+        addon = importlib.import_module("addon")
+        
+        mock_settings = types.SimpleNamespace(
+            has_plan=True,
+            built=True,
+            show_details=True,
+            asset_dir="/some/path",
+            recommended_armature="Rig",
+            mapped=15,
+            total=28,
+            missing_csv="some_missing",
+            missing_by_target_csv="some_target",
+            review_flags_csv="flags",
+            character_ids_csv="ids",
+            is_crowd=True,
+            character_count=5,
+            build_succeeded=4,
+            build_failed=1,
+            failed_characters_csv="char1",
+            synthesized_bones_csv="bone1",
+            synthesized_bones_by_character_csv="char1 (bone1)",
+            show_failed_details=True,
+            show_inert_details=True
+        )
+        
+        # Set up fake_bpy.context
+        self.fake_bpy.context = types.SimpleNamespace(
+            scene=types.SimpleNamespace(open_jaywalker=mock_settings)
+        )
+        
+        # Call the load_post_handler
+        addon.load_post_handler(None, None)
+        
+        # Verify state properties are reset
+        self.assertFalse(mock_settings.has_plan)
+        self.assertFalse(mock_settings.built)
+        self.assertFalse(mock_settings.show_details)
+        self.assertEqual(mock_settings.asset_dir, "")
+        self.assertEqual(mock_settings.recommended_armature, "")
+        self.assertEqual(mock_settings.mapped, 0)
+        self.assertEqual(mock_settings.total, 28)
+        self.assertEqual(mock_settings.missing_csv, "")
+        self.assertEqual(mock_settings.missing_by_target_csv, "")
+        self.assertEqual(mock_settings.review_flags_csv, "")
+        self.assertEqual(mock_settings.character_ids_csv, "")
+        self.assertFalse(mock_settings.is_crowd)
+        self.assertEqual(mock_settings.character_count, 0)
+        self.assertEqual(mock_settings.build_succeeded, 0)
+        self.assertEqual(mock_settings.build_failed, 0)
+        self.assertEqual(mock_settings.failed_characters_csv, "")
+        self.assertEqual(mock_settings.synthesized_bones_csv, "")
+        self.assertEqual(mock_settings.synthesized_bones_by_character_csv, "")
+        self.assertFalse(mock_settings.show_failed_details)
+        self.assertFalse(mock_settings.show_inert_details)
+
+    def test_ui_draw_collapsible_sections_and_reset_button(self):
+        class MockLayout:
+            def __init__(self):
+                self.labels = []
+                self.operators = []
+                self.props = []
+                self.alert = False
+                
+            def separator(self, *args, **kwargs):
+                pass
+                
+            def label(self, text="", icon='NONE', *args, **kwargs):
+                self.labels.append((text, icon))
+                
+            def operator(self, name, icon='NONE', *args, **kwargs):
+                self.operators.append((name, icon))
+                
+            def prop(self, data, prop_name, text="", icon='NONE', emboss=True, *args, **kwargs):
+                self.props.append((prop_name, text, icon, emboss))
+                
+            def row(self, *args, **kwargs):
+                return self
+                
+            def box(self, *args, **kwargs):
+                return self
+                
+            def column(self, align=False, *args, **kwargs):
+                return self
+
+        # Test case 1: Crowd build failed and inert bones warning, collapsed state
+        mock_settings = types.SimpleNamespace(
+            built=True,
+            has_plan=True,
+            is_crowd=True,
+            build_succeeded=1,
+            build_failed=1,
+            failed_characters_csv="char_01",
+            synthesized_bones_csv="",
+            synthesized_bones_by_character_csv="char_01 (Full_Fingers_Left)",
+            asset_dir="/x",
+            recommended_armature="Rig",
+            mapped=28,
+            total=28,
+            missing_csv="",
+            missing_by_target_csv="",
+            review_flags_csv="",
+            character_ids_csv="",
+            character_count=2,
+            show_details=False,
+            export_blend=False,
+            export_gltf=True,
+            per_character_export=False,
+            show_failed_details=False,
+            show_inert_details=False
+        )
+        mock_context = types.SimpleNamespace(scene=types.SimpleNamespace(open_jaywalker=mock_settings))
+        
+        mock_layout = MockLayout()
+        panel = self.ui.OJ_PT_panel()
+        panel.layout = mock_layout
+        panel.draw(mock_context)
+        
+        # Verify reset button is drawn
+        self.assertIn(("open_jaywalker.reset_pipeline", "LOOP_BACK"), mock_layout.operators)
+        
+        # Verify collapsible properties are drawn with TRIA_RIGHT icon (collapsed)
+        self.assertIn(("show_failed_details", "Failed Details", "TRIA_RIGHT", False), mock_layout.props)
+        self.assertIn(("show_inert_details", "Inert Bone Details", "TRIA_RIGHT", False), mock_layout.props)
+        
+        # Since details are false, the actual details shouldn't be drawn (e.g. mock_layout.labels should NOT contain character names or bone details)
+        self.assertNotIn(("   - char_01", "NONE"), mock_layout.labels)
+        
+        # Test case 2: expanded state
+        mock_settings.show_failed_details = True
+        mock_settings.show_inert_details = True
+        
+        mock_layout = MockLayout()
+        panel.layout = mock_layout
+        panel.draw(mock_context)
+        
+        # Verify collapsible properties are drawn with TRIA_DOWN icon (expanded)
+        self.assertIn(("show_failed_details", "Failed Details", "TRIA_DOWN", False), mock_layout.props)
+        self.assertIn(("show_inert_details", "Inert Bone Details", "TRIA_DOWN", False), mock_layout.props)
+        
+        # Verify the details are drawn
+        self.assertIn(("Failed characters:", "NONE"), mock_layout.labels)
+        self.assertIn(("   - char_01", "NONE"), mock_layout.labels)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR implements Issue #53, adding collapsible UI logs and a "Reset Pipeline" operator to clear all pipeline outputs, scene settings, and purge generated rigs/collections.

### Changes:
1. Added `show_failed_details` and `show_inert_details` to the `OJSettings` property group.
2. Implemented the `OJ_OT_reset_pipeline` operator to delete classifier, builder, and plan JSON files on disk, reset all scene properties to defaults, and purge rigs.
3. Registered a persistent `load_post` handler to reset scene properties to a clean state when a file is opened/reopened.
4. Wrapped the "Failed characters" and "Synthesized Inert Bones" sections in collapsible layout boxes in the UI using standard Blender collapse/expand arrows.
5. Added unit tests verifying the reset operator, the startup load handler, and UI drawing behavior under both collapsed and expanded details configurations.

Closes #53
