### PR TITLE
Add glb-to-osgb conversion helper for esmini (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ see [Architecture](https://github.com/roboticrustacean/open-jaywalker/wiki/Archi
 (the 28 core targets, name-free structural inference, decision tags, crowd
 decomposition).
 
+To use the generated `.glb` assets in an OpenSCENARIO simulator such as
+[esmini](https://github.com/eclipse/esmini) (which ingests OpenSceneGraph `.osgb`),
+the repo ships an unsupported post-build conversion helper, `tools/glb_to_osgb.py`,
+that wraps a local `osgconv`. See
+[Using Outputs in esmini / OpenSCENARIO](https://github.com/roboticrustacean/open-jaywalker/wiki/Using-Outputs-in-esmini-and-OpenSCENARIO).
+
 ### Blender Add-on (recommended)
 
 The pipeline ships as an installable Blender add-on, **Open Jaywalker**, which is

--- a/tests/test_glb_to_osgb.py
+++ b/tests/test_glb_to_osgb.py
@@ -1,0 +1,125 @@
+import sys
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOLS = REPO_ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import glb_to_osgb  # noqa: E402
+
+
+class _RecordingRunner:
+    """Stand-in for subprocess.run that records calls instead of executing."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append((list(cmd), kwargs))
+        return 0
+
+
+class ResolveOsgconvTests(unittest.TestCase):
+    def test_explicit_takes_precedence(self):
+        self.assertEqual(
+            glb_to_osgb.resolve_osgconv(explicit="C:/tools/osgconv.exe"),
+            "C:/tools/osgconv.exe",
+        )
+
+    def test_env_var_used_when_no_explicit(self):
+        with unittest.mock.patch.dict("os.environ", {"OSGCONV": "/usr/bin/osgconv"}):
+            with unittest.mock.patch.object(glb_to_osgb.shutil, "which", return_value=None):
+                self.assertEqual(glb_to_osgb.resolve_osgconv(), "/usr/bin/osgconv")
+
+    def test_which_used_as_last_resort(self):
+        with unittest.mock.patch.dict("os.environ", {}, clear=True):
+            with unittest.mock.patch.object(
+                glb_to_osgb.shutil, "which", return_value="/opt/osg/osgconv"
+            ):
+                self.assertEqual(glb_to_osgb.resolve_osgconv(), "/opt/osg/osgconv")
+
+    def test_explicit_beats_env_and_which(self):
+        with unittest.mock.patch.dict("os.environ", {"OSGCONV": "/env/osgconv"}):
+            with unittest.mock.patch.object(
+                glb_to_osgb.shutil, "which", return_value="/which/osgconv"
+            ):
+                self.assertEqual(
+                    glb_to_osgb.resolve_osgconv(explicit="/explicit/osgconv"),
+                    "/explicit/osgconv",
+                )
+
+    def test_unresolved_raises_with_guidance(self):
+        with unittest.mock.patch.dict("os.environ", {}, clear=True):
+            with unittest.mock.patch.object(glb_to_osgb.shutil, "which", return_value=None):
+                with self.assertRaises(FileNotFoundError) as ctx:
+                    glb_to_osgb.resolve_osgconv()
+        self.assertIn("osgconv", str(ctx.exception).lower())
+        self.assertIn("openscenegraph", str(ctx.exception).lower())
+
+
+class OutputPathTests(unittest.TestCase):
+    def test_default_alongside_input(self):
+        out = glb_to_osgb.output_path_for(Path("/a/b/char_asam.glb"))
+        self.assertEqual(out, Path("/a/b/char_asam.osgb"))
+
+    def test_outdir_override(self):
+        out = glb_to_osgb.output_path_for(Path("/a/b/char_asam.glb"), outdir=Path("/out"))
+        self.assertEqual(out, Path("/out/char_asam.osgb"))
+
+
+class BuildCommandTests(unittest.TestCase):
+    def test_argv_shape(self):
+        cmd = glb_to_osgb.build_command("osgconv", Path("in.glb"), Path("out.osgb"))
+        self.assertEqual(cmd, ["osgconv", "in.glb", "out.osgb"])
+
+
+class ConvertTests(unittest.TestCase):
+    def test_missing_input_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            glb_to_osgb.convert(
+                Path("does_not_exist.glb"),
+                osgconv="osgconv",
+                runner=_RecordingRunner(),
+            )
+
+    def test_convert_runs_command_and_returns_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            glb = Path(tmp) / "char_asam.glb"
+            glb.write_bytes(b"glTF-stub")
+            runner = _RecordingRunner()
+            out = glb_to_osgb.convert(glb, osgconv="osgconv", runner=runner)
+            self.assertEqual(out, glb.with_suffix(".osgb"))
+            self.assertEqual(len(runner.calls), 1)
+            cmd, kwargs = runner.calls[0]
+            self.assertEqual(cmd, ["osgconv", str(glb), str(out)])
+            self.assertTrue(kwargs.get("check"))
+
+    def test_convert_outdir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            glb = Path(tmp) / "char_asam.glb"
+            glb.write_bytes(b"glTF-stub")
+            outdir = Path(tmp) / "osgb"
+            runner = _RecordingRunner()
+            out = glb_to_osgb.convert(glb, outdir=outdir, osgconv="osgconv", runner=runner)
+            self.assertEqual(out, outdir / "char_asam.osgb")
+            self.assertTrue(outdir.exists())
+
+    def test_convert_many(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            globs = []
+            for i in range(3):
+                g = Path(tmp) / "char{0}_asam.glb".format(i)
+                g.write_bytes(b"glTF-stub")
+                globs.append(g)
+            runner = _RecordingRunner()
+            outs = glb_to_osgb.convert_many(globs, osgconv="osgconv", runner=runner)
+            self.assertEqual(outs, [g.with_suffix(".osgb") for g in globs])
+            self.assertEqual(len(runner.calls), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/glb_to_osgb.py
+++ b/tools/glb_to_osgb.py
@@ -1,0 +1,103 @@
+"""Convert open-jaywalker's `.glb` exports to OpenSceneGraph `.osgb` for esmini.
+
+open-jaywalker's canonical output is `.glb` (ASAM OpenMATERIAL is glTF-based). esmini
+renders via OpenSceneGraph, which ingests `.osgb`. `.osgb` is not an ASAM/OpenX format
+and OpenSCENARIO does not define a model container -- it is one simulator's ingestion
+detail, on the consumer side of the asset boundary. So this is an *unsupported*,
+post-build convenience that shells out to the user's local `osgconv` (shipped with
+OpenSceneGraph). It is deliberately NOT part of the Blender add-on / core build path.
+
+Resolution order for the `osgconv` executable: explicit argument -> ``OSGCONV`` env var
+-> ``shutil.which("osgconv")``.
+
+Run:
+    python tools/glb_to_osgb.py <glb> [<glb> ...] [--osgconv PATH] [--outdir DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_INSTALL_HINT = (
+    "Could not find the 'osgconv' executable. Install OpenSceneGraph "
+    "(https://github.com/openscenegraph/OpenSceneGraph), then either add it to PATH, "
+    "set the OSGCONV environment variable, or pass --osgconv <path>."
+)
+
+
+def resolve_osgconv(explicit=None) -> str:
+    """Resolve the osgconv executable: explicit arg -> OSGCONV env -> PATH.
+
+    Raises FileNotFoundError with install guidance when none resolve.
+    """
+    candidate = explicit or os.environ.get("OSGCONV") or shutil.which("osgconv")
+    if not candidate:
+        raise FileNotFoundError(_INSTALL_HINT)
+    return candidate
+
+
+def output_path_for(glb_path, outdir=None) -> Path:
+    """Derive the `.osgb` output path for a `.glb` input."""
+    glb_path = Path(glb_path)
+    name = glb_path.with_suffix(".osgb").name
+    return (Path(outdir) / name) if outdir else glb_path.with_suffix(".osgb")
+
+
+def build_command(osgconv, glb_path, osgb_path) -> list:
+    """Construct the osgconv argv. Factored out so it is assertable in tests."""
+    return [osgconv, str(glb_path), str(osgb_path)]
+
+
+def convert(glb_path, *, osgb_path=None, outdir=None, osgconv=None, runner=subprocess.run) -> Path:
+    """Convert one `.glb` to `.osgb`; return the output path.
+
+    Raises FileNotFoundError if the input is missing or osgconv cannot be resolved.
+    `runner` is injectable for testing (defaults to subprocess.run).
+    """
+    glb_path = Path(glb_path)
+    if not glb_path.is_file():
+        raise FileNotFoundError("Input .glb not found: {0}".format(glb_path))
+    exe = resolve_osgconv(osgconv)
+    out = Path(osgb_path) if osgb_path else output_path_for(glb_path, outdir)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    runner(build_command(exe, glb_path, out), check=True)
+    return out
+
+
+def convert_many(glb_paths, *, outdir=None, osgconv=None, runner=subprocess.run) -> list:
+    """Convert several `.glb` files (e.g. a crowd's per-character exports)."""
+    exe = resolve_osgconv(osgconv)
+    return [
+        convert(g, outdir=outdir, osgconv=exe, runner=runner)
+        for g in glb_paths
+    ]
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Convert open-jaywalker .glb exports to .osgb for esmini.",
+    )
+    parser.add_argument("glb", nargs="+", help="one or more .glb files to convert")
+    parser.add_argument("--osgconv", help="path to the osgconv executable")
+    parser.add_argument("--outdir", help="directory for the .osgb outputs")
+    args = parser.parse_args(argv)
+    try:
+        outputs = convert_many(args.glb, outdir=args.outdir, osgconv=args.osgconv)
+    except FileNotFoundError as exc:
+        print("error: {0}".format(exc), file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print("error: osgconv failed (exit {0})".format(exc.returncode), file=sys.stderr)
+        return 1
+    for out in outputs:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements points 1 & 2 of #86's proposed solution; drops point 3.

- Keeps `.glb` as the canonical, ASAM OpenMATERIAL-aligned output (point 1).
- Adds `tools/glb_to_osgb.py`, an **unsupported post-build helper** that wraps a local `osgconv` (resolved via `--osgconv` / `OSGCONV` / `PATH`) to convert one or many `.glb` exports to OpenSceneGraph `.osgb` for esmini (point 2).
- **No** add-on/GUI integration, bundled binary, or Python OSGB serializer (point 3 dropped). The core build path is untouched, so the single-character byte-for-byte invariant holds.

`.osgb` is not an ASAM/OpenX format — OpenSCENARIO does not define a 3D model container, so conversion lives on the consumer side of the asset boundary.

## Tests

- New `tests/test_glb_to_osgb.py` (12 tests, pure-Python, `osgconv` not required — runner injected/mocked).
- Full suite green: `python -m unittest discover tests` → 355 passing.

## Docs

- Wiki: new [Using Outputs in esmini / OpenSCENARIO](https://github.com/roboticrustacean/open-jaywalker/wiki/Using-Outputs-in-esmini-and-OpenSCENARIO) page; boundary note added to Standards-and-Compliance.
- README points to the helper + wiki page.

Closes #86.