### PR TITLE
Document esmini conversion findings (glb→obj→osgb)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ decomposition).
 To use the generated `.glb` assets in an OpenSCENARIO simulator such as
 [esmini](https://github.com/eclipse/esmini) (which ingests OpenSceneGraph `.osgb`),
 the repo ships an unsupported post-build conversion helper, `tools/glb_to_osgb.py`,
-that wraps a local `osgconv`. See
-[Using Outputs in esmini / OpenSCENARIO](https://github.com/roboticrustacean/open-jaywalker/wiki/Using-Outputs-in-esmini-and-OpenSCENARIO).
+that wraps a local `osgconv`. Note that stock OpenSceneGraph builds cannot read `.glb`
+directly (no glTF plugin), so the portable route is `.glb → .obj → .osgb`. The
+[Using Outputs in esmini / OpenSCENARIO](https://github.com/roboticrustacean/open-jaywalker/wiki/Using-Outputs-in-esmini-and-OpenSCENARIO)
+wiki page has the verified end-to-end recipe plus the scale and texture caveats.
 
 ### Blender Add-on (recommended)
 

--- a/tools/glb_to_osgb.py
+++ b/tools/glb_to_osgb.py
@@ -10,8 +10,17 @@ OpenSceneGraph). It is deliberately NOT part of the Blender add-on / core build 
 Resolution order for the `osgconv` executable: explicit argument -> ``OSGCONV`` env var
 -> ``shutil.which("osgconv")``.
 
+IMPORTANT -- input format depends on osgconv's plugins. ``osgconv`` can only read a
+format it has a plugin for. **Stock Windows OpenSceneGraph prebuilds ship no glTF/assimp
+read plugin**, so a direct ``.glb`` conversion fails with "Could not find plugin to read
+objects". The portable route is ``.glb`` -> ``.obj`` -> ``.osgb`` (export ``.obj`` from
+Blender; the ``.obj`` plugin is standard and preserves metres). This helper passes the
+input straight to osgconv, so it works on ``.obj``/``.fbx`` inputs too -- not only
+``.glb``. See the wiki page "Using Outputs in esmini / OpenSCENARIO" for the full recipe
+and the texture/scale caveats.
+
 Run:
-    python tools/glb_to_osgb.py <glb> [<glb> ...] [--osgconv PATH] [--outdir DIR]
+    python tools/glb_to_osgb.py <model> [<model> ...] [--osgconv PATH] [--outdir DIR]
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Follow-up to #86 after end-to-end validation in esmini.

## What changed
- **README** + **helper docstring**: document that stock `osgconv` builds cannot read `.glb` (no glTF plugin), so the portable route is `.glb → .obj → .osgb`. The helper already accepts any osgconv-readable input (works on `.obj`/`.fbx`), so no code/behavior change.
- **Wiki** (`Using Outputs in esmini / OpenSCENARIO`): rewritten conversion section with the verified recipe, `osgconv --formats` gate, `osgviewer` quick-check, correct `model3d` scenario wiring, and a findings table.

## Validation (esmini v3.2.1, OSG 3.6.5, openmatexamplehuman)
- Direct `.glb→.osgb`: ❌ "Could not find plugin to read objects".
- `.glb→.obj→.osgb`: ✅ correct scale (bbox lwh 0.37/1.09/1.78, z=0.89); esmini ran to QuitCondition.
- `.glb→.fbx→.osgb`: ⚠️ loads but ~100× (Blender FBX cm/m scaling).
- Textures drop on the OBJ route because glTF-embedded images are packed in Blender and not unpacked on OBJ export — a conversion artifact, not an asset defect.

Docs-only; no behavior change. Tests green (358).