### PR TITLE
Collapse non-core extras into core (single mechanism); fix #88 spiky build

### DIFF
--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -657,28 +657,50 @@ def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones:
                 "parent": "Hip",
             }
         )
-    # Build lookup map: source_bone_name -> final_bone_name
+    # Materialize only extras that actually skin the mesh. The classifier flags every
+    # non-core source bone as an extra, which for a control rig (Rigify) includes
+    # hundreds of non-deforming MCH-/VIS-/IK/FK bones. Adding those to the generated
+    # armature clutters it with stray (often long pole) bones that deform nothing - the
+    # #88 "spiky build" regression. The durable rule is to build from what the mesh is
+    # weighted to, so an extra is preserved only when it carries skin weight.
+    mesh_binding = build_plan.get("mesh_binding", {})
+    kept_extra_names = [
+        extra.get("bone_name")
+        for extra in spec["extras_preserved"]
+        if extra.get("bone_name") in source_bones
+        and _bone_has_skin_weight(extra.get("bone_name"), mesh_binding)
+    ]
+
+    # Map source bone name -> final (in-armature) bone name: core/pelvis/root bones
+    # already in spec["bones"], plus the kept extras (which keep their own names).
     source_to_final_name = {}
     for bone in spec["bones"]:
         src_name = bone.get("source_bone")
         if src_name:
             source_to_final_name[src_name] = bone["name"]
-    for extra in spec["extras_preserved"]:
-        extra_name = extra.get("bone_name")
-        if extra_name:
-            source_to_final_name[extra_name] = extra_name
+    for extra_name in kept_extra_names:
+        source_to_final_name[extra_name] = extra_name
 
-    for extra in spec["extras_preserved"]:
-        extra_name = extra.get("bone_name")
-        if not extra_name or extra_name not in source_bones:
-            continue
+    def _resolve_extra_parent(parent_name):
+        # Walk up the source parent chain to the nearest bone that exists in the
+        # generated armature, so a kept extra never dangles off a dropped parent.
+        seen = set()
+        current = parent_name
+        while current and current not in seen:
+            seen.add(current)
+            mapped = source_to_final_name.get(current)
+            if mapped:
+                return mapped
+            geom = source_bones.get(current)
+            current = geom.get("parent") if geom else None
+        return None
+
+    for extra_name in kept_extra_names:
         geom = source_bones[extra_name]
-        parent_name = geom.get("parent")
-        final_parent = source_to_final_name.get(parent_name) if parent_name else None
         spec["bones"].append(
             {
                 "name": extra_name,
-                "parent_bone": final_parent,
+                "parent_bone": _resolve_extra_parent(geom.get("parent")),
                 "head": _to_grp_root_local(geom["head"], grp_root_local_origin),
                 "tail": _to_grp_root_local(geom["tail"], grp_root_local_origin),
                 "use_connect": False,

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -657,58 +657,23 @@ def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones:
                 "parent": "Hip",
             }
         )
-    # Materialize only extras that actually skin the mesh. The classifier flags every
-    # non-core source bone as an extra, which for a control rig (Rigify) includes
-    # hundreds of non-deforming MCH-/VIS-/IK/FK bones. Adding those to the generated
-    # armature clutters it with stray (often long pole) bones that deform nothing - the
-    # #88 "spiky build" regression. The durable rule is to build from what the mesh is
-    # weighted to, so an extra is preserved only when it carries skin weight.
+    # Non-core source bones are NOT materialized as bones. The classifier flags every
+    # non-core bone as an extra, which for a control rig (Rigify) is hundreds of
+    # non-deforming MCH-/VIS-/IK/FK bones; materializing them all (#88) filled the clean
+    # ASAM armature with stray, often long pole bones - the "spiky build". The coherent
+    # rule is a single mechanism: the 28 core is the skeleton, and every non-core deform
+    # bone's skin weights are consolidated into the nearest core bone by
+    # _compute_weight_merges above (lossless - the mesh stays fully weighted). Control
+    # bones skin nothing, so they simply never appear. Genuine separate-mesh decorators
+    # (hair/clothing/accessories with their own mesh) are a future additive feature,
+    # preserved via ASAM Hair_/Clothing_/Accessories_ containers rather than as body-mesh
+    # skeleton subdivisions.
     mesh_binding = build_plan.get("mesh_binding", {})
-    kept_extra_names = [
-        extra.get("bone_name")
-        for extra in spec["extras_preserved"]
-        if extra.get("bone_name") in source_bones
-        and _bone_has_skin_weight(extra.get("bone_name"), mesh_binding)
-    ]
-
-    # Map source bone name -> final (in-armature) bone name: core/pelvis/root bones
-    # already in spec["bones"], plus the kept extras (which keep their own names).
-    source_to_final_name = {}
-    for bone in spec["bones"]:
-        src_name = bone.get("source_bone")
-        if src_name:
-            source_to_final_name[src_name] = bone["name"]
-    for extra_name in kept_extra_names:
-        source_to_final_name[extra_name] = extra_name
-
-    def _resolve_extra_parent(parent_name):
-        # Walk up the source parent chain to the nearest bone that exists in the
-        # generated armature, so a kept extra never dangles off a dropped parent.
-        seen = set()
-        current = parent_name
-        while current and current not in seen:
-            seen.add(current)
-            mapped = source_to_final_name.get(current)
-            if mapped:
-                return mapped
-            geom = source_bones.get(current)
-            current = geom.get("parent") if geom else None
-        return None
-
-    for extra_name in kept_extra_names:
-        geom = source_bones[extra_name]
-        spec["bones"].append(
-            {
-                "name": extra_name,
-                "parent_bone": _resolve_extra_parent(geom.get("parent")),
-                "head": _to_grp_root_local(geom["head"], grp_root_local_origin),
-                "tail": _to_grp_root_local(geom["tail"], grp_root_local_origin),
-                "use_connect": False,
-                "geometry_source": "source_bone",
-                "source_bone": extra_name,
-                "semantic_action": "preserve_extra",
-            }
-        )
+    spec["merged_extra_deform_count"] = sum(
+        1
+        for merge in spec["weight_merges"]
+        if _bone_has_skin_weight(merge["source"], mesh_binding)
+    )
 
     return spec
 
@@ -754,7 +719,7 @@ def build_builder_report(build_spec: dict, execution_result: dict) -> dict:
         "built_core_targets": [bone["name"] for bone in build_spec["bones"] if bone["name"] in core_target_names],
         "targets_from_source_geometry": source_targets,
         "targets_created_heuristically": created_targets,
-        "preserved_extras_count": len(build_spec.get("extras_preserved", [])),
+        "merged_extra_deform_count": build_spec.get("merged_extra_deform_count", 0),
         "preserved_pelvis_pair": copy.deepcopy(build_spec.get("preserved_pelvis_pair", [])),
         "hidden_source_objects": list(execution_result.get("hidden_source_objects", [])),
         "warnings": list(build_spec.get("warnings", [])),
@@ -782,10 +747,10 @@ def success_message(builder_report: dict, report_path) -> str:
             built, failed, report_path
         )
     core = len(builder_report.get("built_core_targets", []))
-    extras = builder_report.get("preserved_extras_count", 0)
+    merged = builder_report.get("merged_extra_deform_count", 0)
     asset = builder_report.get("asset_name", "")
-    return "ASAM human built: {0} - {1} core targets, {2} extras preserved. Report: {3}".format(
-        asset, core, extras, report_path
+    return "ASAM human built: {0} - {1} core targets, {2} extra deform bones merged into core. Report: {3}".format(
+        asset, core, merged, report_path
     )
 
 
@@ -812,7 +777,7 @@ def print_builder_summary(builder_report: dict, report_path: Path) -> None:
             ", ".join(builder_report["targets_created_heuristically"]) or "(none)"
         )
     )
-    print("Preserved extras count: {0}".format(builder_report["preserved_extras_count"]))
+    print("Extra deform bones merged into core: {0}".format(builder_report.get("merged_extra_deform_count", 0)))
     preserved_pair = builder_report.get("preserved_pelvis_pair", [])
     if preserved_pair:
         print(

--- a/src/phase3_classifier/classifier.py
+++ b/src/phase3_classifier/classifier.py
@@ -586,7 +586,7 @@ def print_console_summary(report: dict, plan: dict, report_path: Path, plan_path
         else:
             print("  (none)")
     print("Ambiguous targets: {0}".format(", ".join(item["target"] for item in report["ambiguous_targets"]) or "(none)"))
-    print("Preserved extras count: {0}".format(len(plan["extras_preserved"])))
+    print("Non-core bones flagged as extras: {0}".format(len(plan["extras_preserved"])))
     print("Report written to: {0}".format(report_path))
     print("Build plan written to: {0}".format(plan_path))
 

--- a/tests/fixtures/LowPolyCharacter4/builder_report.json
+++ b/tests/fixtures/LowPolyCharacter4/builder_report.json
@@ -188,6 +188,6 @@
     "Full_Thumb_Right",
     "Full_Fingers_Right"
   ],
-  "preserved_extras_count": 128,
+  "merged_extra_deform_count": 12,
   "warnings": []
 }

--- a/tests/fixtures/openmatexamplehuman/builder_report.json
+++ b/tests/fixtures/openmatexamplehuman/builder_report.json
@@ -94,6 +94,6 @@
   "targets_created_heuristically": [
     "Root"
   ],
-  "preserved_extras_count": 8,
+  "merged_extra_deform_count": 0,
   "warnings": []
 }

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -950,6 +950,35 @@ class AsamHumanBuilderTests(unittest.TestCase):
             self.assertEqual(preserved_bone["source_bone"], source_name)
             self.assertEqual(preserved_bone["semantic_action"], "preserve_paired_pelvis")
 
+    def test_preserved_extras_only_materialize_mesh_driving_bones(self):
+        """Regression for #88: only extras that actually skin the mesh become bones.
+
+        The Rigify LowPolyCharacter4 rig flags 153 extras, but 140+ of them are
+        non-deforming control/mechanism/pole bones (MCH-/VIS-/IK/FK). Materializing
+        those into the generated armature clutters it with stray (often long pole)
+        bones - the "spiky" build. The durable rule (CLAUDE.md) is to build from what
+        the mesh is weighted to, so a preserved extra must carry skin weight, and its
+        parent must be a bone that actually exists in the generated armature.
+        """
+        from asam_human_builder.builder import _bone_has_skin_weight
+
+        asset_dir = _copy_asset_folder("LowPolyCharacter4")
+        write_asset_report(asset_dir)
+        _, build_plan, build_spec = build_armature_spec_from_asset_dir(asset_dir)
+
+        extra_bones = [b for b in build_spec["bones"] if b.get("semantic_action") == "preserve_extra"]
+        # The legitimate mesh-driving extras (DEF- segments + Hair) survive.
+        self.assertGreater(len(extra_bones), 0)
+
+        # No non-deforming control/mechanism/visualization bones leak in.
+        leaked = [b["name"] for b in extra_bones if not _bone_has_skin_weight(b["source_bone"], build_plan["mesh_binding"])]
+        self.assertEqual(leaked, [], "non-mesh-driving extras must not become bones")
+
+        # Every materialized extra parents onto a bone that exists in the armature.
+        all_names = {b["name"] for b in build_spec["bones"]}
+        orphans = [b["name"] for b in extra_bones if b["parent_bone"] is not None and b["parent_bone"] not in all_names]
+        self.assertEqual(orphans, [], "preserved extras must not have dangling parents")
+
     def test_lowpoly_central_chain_is_monotonic_and_continuous(self):
         # Regression for #73: the spanned central chain Hip -> Lower_Spine ->
         # Upper_Spine -> Neck -> Head on the real LowPolyCharacter4 rig must render as
@@ -3571,7 +3600,14 @@ class EyeFingerDispatchTests(unittest.TestCase):
         plan["extras_preserved"] = [
             {"bone_name": "DEF-hair", "reason": "named_extra", "origin": "primary", "role": "deform"}
         ]
-        
+        # DEF-hair represents a real hair bone that skins a hair mesh, so it must
+        # report skin weight for the build to materialize it (mesh-driven rule).
+        plan["mesh_binding"]["meshes"][0]["vertex_groups"] = ["DEF-hair"]
+        plan["mesh_binding"]["meshes"][0]["vertex_group_stats"] = {
+            "non_empty_group_count": 1,
+            "per_group": [{"name": "DEF-hair", "weighted_vertex_count": 9}],
+        }
+
         # Lower_Arm_Left is mapped to DEF-forearm.L
         report["semantic_mapping"]["Lower_Arm_Left"]["action"] = "direct_map"
         report["semantic_mapping"]["Lower_Arm_Left"]["source_bone"] = "DEF-forearm.L"

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -873,7 +873,7 @@ class AsamHumanBuilderTests(unittest.TestCase):
         self.assertFalse(edit_bones["Full_Thumb_Left"].hide, "Mapped extremity bone should remain visible")
         self.assertFalse(edit_bones["Hip"].hide, "Non-extremity bones should remain visible even when heuristic")
 
-    def test_lowpoly_fixture_creates_new_root_and_preserves_extras(self):
+    def test_lowpoly_fixture_creates_new_root_and_collapses_extras(self):
         asset_dir = _copy_asset_folder("LowPolyCharacter4")
         write_asset_report(asset_dir)
 
@@ -881,6 +881,7 @@ class AsamHumanBuilderTests(unittest.TestCase):
 
         self.assertEqual(build_plan["root_resolutions"][0]["mode"], "create_new_root")
         self.assertEqual(build_spec["source_armature_name"], "rig")
+        # The classifier still flags the non-core bones (for the report/traceability).
         self.assertGreater(len(build_spec["extras_preserved"]), 0)
 
         # Root preservation is disabled: the generated armature must contain exactly
@@ -892,12 +893,13 @@ class AsamHumanBuilderTests(unittest.TestCase):
             [],
         )
 
-        # Verify that preserved extra bones are added to build_spec["bones"]
+        # No extras are materialized as bones; their weights collapse into core via
+        # the single weight_merges mechanism (e.g. the baked-in hair bone -> core).
         extra_bones = [bone for bone in build_spec["bones"] if bone.get("semantic_action") == "preserve_extra"]
-        self.assertGreater(len(extra_bones), 0)
-        hair_bone = _spec_bone(build_spec, "Hair_Front")
-        self.assertEqual(hair_bone["parent_bone"], "DEF-spine.006")
-        self.assertEqual(hair_bone["semantic_action"], "preserve_extra")
+        self.assertEqual(extra_bones, [])
+        merges = {m["source"]: m["target"] for m in build_spec["weight_merges"]}
+        self.assertIn("Hair_Front", merges)
+        self.assertIn(merges["Hair_Front"], set(CORE_TARGETS))
 
         root_bone = _spec_bone(build_spec, "Root")
         self.assertEqual(root_bone["geometry_source"], "root_resolution")
@@ -950,34 +952,38 @@ class AsamHumanBuilderTests(unittest.TestCase):
             self.assertEqual(preserved_bone["source_bone"], source_name)
             self.assertEqual(preserved_bone["semantic_action"], "preserve_paired_pelvis")
 
-    def test_preserved_extras_only_materialize_mesh_driving_bones(self):
-        """Regression for #88: only extras that actually skin the mesh become bones.
+    def test_non_core_deform_extras_collapse_into_core(self):
+        """#88 regression: non-core source bones are NOT materialized as bones; a
+        single mechanism (weight_merges) consolidates their skin weights into core.
 
-        The Rigify LowPolyCharacter4 rig flags 153 extras, but 140+ of them are
-        non-deforming control/mechanism/pole bones (MCH-/VIS-/IK/FK). Materializing
-        those into the generated armature clutters it with stray (often long pole)
-        bones - the "spiky" build. The durable rule (CLAUDE.md) is to build from what
-        the mesh is weighted to, so a preserved extra must carry skin weight, and its
-        parent must be a bone that actually exists in the generated armature.
+        The Rigify LowPolyCharacter4 rig flags 153 extras (140+ non-deforming
+        MCH-/VIS-/IK/FK control bones). Materializing them filled the clean ASAM
+        armature with stray (often long pole) bones - the "spiky" build - and even the
+        mesh-driving subdivisions overlapped with weight_merges, leaving weightless
+        clutter. The coherent rule: the 28 core is the skeleton, every non-core deform
+        weight is merged into core (lossless), control bones never appear. Genuine
+        separate-mesh decorators are a future additive feature (ASAM Hair_/Clothing_
+        containers).
         """
-        from asam_human_builder.builder import _bone_has_skin_weight
-
         asset_dir = _copy_asset_folder("LowPolyCharacter4")
         write_asset_report(asset_dir)
         _, build_plan, build_spec = build_armature_spec_from_asset_dir(asset_dir)
 
+        # No extras are materialized as bones - one mechanism, no conflict.
         extra_bones = [b for b in build_spec["bones"] if b.get("semantic_action") == "preserve_extra"]
-        # The legitimate mesh-driving extras (DEF- segments + Hair) survive.
-        self.assertGreater(len(extra_bones), 0)
+        self.assertEqual(extra_bones, [])
 
-        # No non-deforming control/mechanism/visualization bones leak in.
-        leaked = [b["name"] for b in extra_bones if not _bone_has_skin_weight(b["source_bone"], build_plan["mesh_binding"])]
-        self.assertEqual(leaked, [], "non-mesh-driving extras must not become bones")
+        # No non-deforming control/mechanism/visualization bone leaks in.
+        names = {b["name"] for b in build_spec["bones"]}
+        self.assertEqual([n for n in names if n.startswith(("MCH-", "VIS-", "ORG-"))], [])
 
-        # Every materialized extra parents onto a bone that exists in the armature.
-        all_names = {b["name"] for b in build_spec["bones"]}
-        orphans = [b["name"] for b in extra_bones if b["parent_bone"] is not None and b["parent_bone"] not in all_names]
-        self.assertEqual(orphans, [], "preserved extras must not have dangling parents")
+        # Every non-core deform bone's weights are consolidated into a core target,
+        # so no skin weight is lost (spine subdivisions, twist bones, baked-in hair).
+        merges = {m["source"]: m["target"] for m in build_spec["weight_merges"]}
+        core = set(CORE_TARGETS)
+        for src in ("DEF-spine.006", "DEF-spine.002", "DEF-forearm.L.001", "Hair_Front"):
+            self.assertIn(src, merges, "{0} weights must be consolidated".format(src))
+            self.assertIn(merges[src], core, "{0} must merge into a core bone".format(src))
 
     def test_lowpoly_central_chain_is_monotonic_and_continuous(self):
         # Regression for #73: the spanned central chain Hip -> Lower_Spine ->
@@ -2713,12 +2719,12 @@ class SuccessMessageTests(unittest.TestCase):
         report = {
             "asset_name": "LowPolyCharacter4",
             "built_core_targets": ["Hip"] * 28,
-            "preserved_extras_count": 153,
+            "merged_extra_deform_count": 12,
         }
         msg = success_message(report, "/out/builder_report.json")
         self.assertIn("LowPolyCharacter4", msg)
         self.assertIn("28 core targets", msg)
-        self.assertIn("153 extras", msg)
+        self.assertIn("12 extra deform", msg)
         self.assertIn("/out/builder_report.json", msg)
 
     def test_crowd_message(self):
@@ -3591,17 +3597,15 @@ class EyeFingerDispatchTests(unittest.TestCase):
         self.assertEqual(source, "source_bone")   # direct map, not eye_anchored
         self.assertEqual(bone, "L_eye")
 
-    def test_build_armature_spec_preserves_extras(self):
+    def test_build_armature_spec_collapses_extras_into_core(self):
         from asam_human_builder.builder import build_armature_spec
         report = _base_classifier_report()
         plan = _base_build_plan()
-        
-        # Add an extra bone in extras_preserved
+
+        # A non-core deform bone (a hair bone skinning the body mesh).
         plan["extras_preserved"] = [
             {"bone_name": "DEF-hair", "reason": "named_extra", "origin": "primary", "role": "deform"}
         ]
-        # DEF-hair represents a real hair bone that skins a hair mesh, so it must
-        # report skin weight for the build to materialize it (mesh-driven rule).
         plan["mesh_binding"]["meshes"][0]["vertex_groups"] = ["DEF-hair"]
         plan["mesh_binding"]["meshes"][0]["vertex_group_stats"] = {
             "non_empty_group_count": 1,
@@ -3611,26 +3615,25 @@ class EyeFingerDispatchTests(unittest.TestCase):
         # Lower_Arm_Left is mapped to DEF-forearm.L
         report["semantic_mapping"]["Lower_Arm_Left"]["action"] = "direct_map"
         report["semantic_mapping"]["Lower_Arm_Left"]["source_bone"] = "DEF-forearm.L"
-        
-        # Set up source bones: DEF-hair has parent DEF-forearm.L
+
+        # DEF-hair has parent DEF-forearm.L (which maps to the core Lower_Arm_Left).
         source_bones = {
             "DEF-forearm.L": _bone("DEF-forearm.L", "DEF-upper_arm.L", (0.0, 0.0, 1.0), (0.0, 0.0, 1.5)),
             "DEF-hair": _bone("DEF-hair", "DEF-forearm.L", (0.0, 0.0, 1.5), (0.0, 0.0, 2.0)),
         }
-        
+
         spec = build_armature_spec(report, plan, source_bones)
-        
-        # Verify extras_preserved contains DEF-hair
+
+        # The classifier's extras list is carried through for the report...
         self.assertEqual(len(spec["extras_preserved"]), 1)
         self.assertEqual(spec["extras_preserved"][0]["bone_name"], "DEF-hair")
-        
-        # Verify the bone was added to spec["bones"]
-        extra_bone = next((b for b in spec["bones"] if b["name"] == "DEF-hair"), None)
-        self.assertIsNotNone(extra_bone)
-        self.assertEqual(extra_bone["source_bone"], "DEF-hair")
-        self.assertEqual(extra_bone["parent_bone"], "Lower_Arm_Left")  # Resolved parent to mapped target name
-        self.assertEqual(extra_bone["semantic_action"], "preserve_extra")
-        self.assertEqual(extra_bone["geometry_source"], "source_bone")
+
+        # ...but DEF-hair is NOT materialized as a bone.
+        self.assertIsNone(next((b for b in spec["bones"] if b["name"] == "DEF-hair"), None))
+
+        # Its skin weights collapse into the core target its parent maps to.
+        merges = {m["source"]: m["target"] for m in spec["weight_merges"]}
+        self.assertEqual(merges.get("DEF-hair"), "Lower_Arm_Left")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
#88 materialized **every** classifier-flagged extra into the generated armature. For a Rigify rig (LowPolyCharacter4) that's **153 extras, 140+ non-deforming** control/mechanism/pole bones (MCH-/VIS-/IK/FK) → the clean ASAM armature filled with stray, often long pole bones = the **"spiky build"**. `openmatexamplehuman` (0 extras) was unaffected — which is why only Rigify rigs broke.

Worse, it created **two conflicting mechanisms**: `_compute_weight_merges` (#58) already consolidates a non-core deform bone's weights into core, but #88 *also* re-materialized the same bone → weightless clutter.

## Fix: one coherent rule
The 28 core is the skeleton. Every non-core **deform** bone's skin weights are merged into the nearest core bone (lossless — mesh stays fully weighted, identical at rest). Control bones skin nothing, so they never appear. Spine subdivisions and limb/twist bones are now handled **identically** — no more spine-vs-extras inconsistency.

Genuine **separate-mesh decorators** (hair/clothing/accessories with their own mesh) become a clean **additive follow-up** via ASAM `Hair_`/`Clothing_`/`Accessories_` containers — not body-mesh skeleton subdivisions. None exist in current test assets, so nothing regresses.

Grounded in the ASAM OpenMATERIAL human spec: core list is a *minimum framework*, the spine is *not subdivided*, and decorators live in *their own containers distinct from the skeleton*.

## Result
LowPolyCharacter4: **153 flagged → 0 materialized**, ~30-bone clean armature, body fully weighted via merges. Report field `preserved_extras_count` (misleading) → `merged_extra_deform_count` (=12).

## Tests
Rewrote the #88 tests to assert the collapse contract (no non-core bones; extra deform weights present in `weight_merges`; no MCH/VIS leak). Full suite green: **359**.

Supersedes #88's approach. Closes the spiky-build regression; refile #68 as decorator-container preservation.