### PR TITLE
ASAM geometry containers: Body_<Asset> + meshes as Grp_Root siblings (#68)

### DIFF
--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -120,6 +120,7 @@ def build_armature_in_blender(build_spec: dict, bpy_module=None, parent_collecti
         collection,
         source_armature,
         armature_object,
+        group_root,
         character_prefix,
         placement_delta,
     )
@@ -358,6 +359,7 @@ def _duplicate_bound_meshes(
     collection,
     source_armature,
     generated_armature,
+    group_root,
     character_prefix=None,
     placement_delta=(0.0, 0.0, 0.0),
 ) -> dict:
@@ -382,12 +384,19 @@ def _duplicate_bound_meshes(
             skipped_meshes.append({"mesh_name": mesh_name, "reason": "source_object_not_mesh"})
             continue
 
+        is_body = mesh_name == build_spec.get("body_mesh_name")
+        base_name = (
+            "Body_{0}".format(build_spec["asset_name"])
+            if is_body
+            else "ASAM_{0}".format(source_mesh.name)
+        )
         generated_mesh = _copy_mesh_object(
             bpy_module,
             source_mesh,
             build_spec["asset_name"],
             collection,
-            generated_armature,
+            group_root,
+            base_name,
             placement_delta,
         )
         retargeted = _retarget_armature_modifiers(generated_mesh, source_armature, generated_armature)
@@ -423,6 +432,8 @@ def _duplicate_bound_meshes(
                 "generated_mesh_name": generated_mesh.name,
                 "armature_link": record.get("armature_link"),
                 "retargeted_armature_modifiers": retargeted,
+                "role": "body" if is_body else "extra",
+                "parent": group_root.name,
                 "vertex_group_remap": {
                     "renamed": remap_plan["renames"],
                     "unmapped": remap_plan["unmapped_groups"],
@@ -448,6 +459,7 @@ def _copy_mesh_object(
     asset_name: str,
     collection,
     parent_object,
+    base_name: str,
     placement_delta=(0.0, 0.0, 0.0),
 ):
     """Duplicate a mesh object, parent it to parent_object, and place it on its rig.
@@ -461,9 +473,9 @@ def _copy_mesh_object(
     """
     generated_mesh = source_mesh.copy()
     generated_mesh.name = _resolve_unique_name(
-        "ASAM_{0}".format(source_mesh.name),
+        base_name,
         lambda name: bpy_module.data.objects.get(name) is not None,
-        ["ASAM_{0}_Generated".format(source_mesh.name)],
+        ["{0}_Generated".format(base_name)],
     )
     if getattr(source_mesh, "data", None) is not None:
         generated_mesh.data = source_mesh.data.copy()
@@ -475,7 +487,7 @@ def _copy_mesh_object(
     generated_mesh[GENERATED_MARKER_KEY] = True
     generated_mesh[GENERATED_ASSET_KEY] = asset_name
     collection.objects.link(generated_mesh)
-    # Parent to the generated armature (one level below group_root) to match ASAM hierarchy.
+    # Parent to Grp_Root (sibling of the armature) per the ASAM geometry-container hierarchy.
     generated_mesh.parent = parent_object
     if world_matrix is not None:
         generated_mesh.matrix_world = _translated_matrix(world_matrix, placement_delta)

--- a/src/asam_human_builder/builder.py
+++ b/src/asam_human_builder/builder.py
@@ -675,6 +675,10 @@ def build_armature_spec(classifier_report: dict, build_plan: dict, source_bones:
         if _bone_has_skin_weight(merge["source"], mesh_binding)
     )
 
+    spec["body_mesh_name"] = _select_body_mesh(
+        mesh_binding, spec["bones"], spec["weight_merges"]
+    )
+
     return spec
 
 
@@ -814,6 +818,50 @@ def _bone_has_skin_weight(source_bone_name: str, mesh_binding: dict) -> bool:
             except (TypeError, ValueError):
                 continue
     return False
+
+
+def _select_body_mesh(mesh_binding, spec_bones, weight_merges):
+    """Pick the body mesh by weighted core coverage (name-free). Returns a mesh_name or None.
+
+    Body score = number of a mesh's vertex groups that have weighted_vertex_count > 0 AND
+    resolve to a core target (the group is a core target's source_bone, is itself a core
+    target name, or maps to a core target via weight_merges). Tie-break by total weighted
+    vertices, then by mesh_name (deterministic). Returns None when no mesh scores > 0.
+    """
+    core_sources = set()
+    for bone in spec_bones or []:
+        if bone.get("name") in CORE_TARGETS:
+            core_sources.add(bone["name"])
+            if bone.get("source_bone"):
+                core_sources.add(bone["source_bone"])
+    for merge in weight_merges or []:
+        if merge.get("target") in CORE_TARGETS:
+            core_sources.add(merge.get("source"))
+
+    candidates = []
+    for mesh in (mesh_binding or {}).get("meshes", []) or []:
+        name = mesh.get("mesh_name")
+        if not name:
+            continue
+        score = 0
+        total = 0
+        stats = mesh.get("vertex_group_stats") or {}
+        for group in stats.get("per_group", []) or []:
+            try:
+                count = int(group.get("weighted_vertex_count") or 0)
+            except (TypeError, ValueError):
+                count = 0
+            if count <= 0:
+                continue
+            total += count
+            if group.get("name") in core_sources:
+                score += 1
+        if score > 0:
+            candidates.append((score, total, name))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda c: (-c[0], -c[1], c[2]))
+    return candidates[0][2]
 
 
 def _resolve_preserved_pelvis_pair(

--- a/tests/fixtures/LowPolyCharacter4/builder_report.json
+++ b/tests/fixtures/LowPolyCharacter4/builder_report.json
@@ -15,11 +15,13 @@
   "duplicated_meshes": [
     {
       "source_mesh_name": "Cube",
-      "generated_mesh_name": "ASAM_Cube",
+      "generated_mesh_name": "Body_LowPolyCharacter4",
       "armature_link": "parent_and_modifier",
       "retargeted_armature_modifiers": [
         "Armature"
       ],
+      "role": "body",
+      "parent": "Grp_Root",
       "vertex_group_remap": {
         "renamed": [
           {

--- a/tests/fixtures/openmatexamplehuman/builder_report.json
+++ b/tests/fixtures/openmatexamplehuman/builder_report.json
@@ -19,15 +19,19 @@
       "armature_link": "parent_and_modifier",
       "retargeted_armature_modifiers": [
         "Armature"
-      ]
+      ],
+      "role": "extra",
+      "parent": "Grp_Root_openmatexamplehuman"
     },
     {
       "source_mesh_name": "Body_Human",
-      "generated_mesh_name": "ASAM_Body_Human",
+      "generated_mesh_name": "Body_openmatexamplehuman",
       "armature_link": "parent_and_modifier",
       "retargeted_armature_modifiers": [
         "Armature"
-      ]
+      ],
+      "role": "body",
+      "parent": "Grp_Root_openmatexamplehuman"
     },
     {
       "source_mesh_name": "Clothing_Vest",
@@ -35,7 +39,9 @@
       "armature_link": "parent_and_modifier",
       "retargeted_armature_modifiers": [
         "Armature"
-      ]
+      ],
+      "role": "extra",
+      "parent": "Grp_Root_openmatexamplehuman"
     },
     {
       "source_mesh_name": "Hair_Short",
@@ -43,7 +49,9 @@
       "armature_link": "parent_and_modifier",
       "retargeted_armature_modifiers": [
         "Armature"
-      ]
+      ],
+      "role": "extra",
+      "parent": "Grp_Root_openmatexamplehuman"
     }
   ],
   "skipped_meshes": [],

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -1600,6 +1600,20 @@ class AsamHumanBuilderTests(unittest.TestCase):
         self.assertEqual(builder_report["grp_root_location"], spec["grp_root_world_location"])
         self.assertIsNone(builder_report["applied_grid_offset"])
 
+    def test_select_body_mesh_picks_broadest_weighted_core_coverage(self):
+        # openmatexamplehuman: Body_Human is weighted across the core skeleton (27),
+        # decorators only on a few bones (6/1/1) -> Body_Human is the body mesh.
+        asset_dir = _copy_asset_folder("openmatexamplehuman")
+        write_asset_report(asset_dir)
+        _, _, build_spec = build_armature_spec_from_asset_dir(asset_dir)
+        self.assertEqual(build_spec["body_mesh_name"], "Body_Human")
+
+    def test_select_body_mesh_lowpoly_single_mesh(self):
+        asset_dir = _copy_asset_folder("LowPolyCharacter4")
+        write_asset_report(asset_dir)
+        _, _, build_spec = build_armature_spec_from_asset_dir(asset_dir)
+        self.assertEqual(build_spec["body_mesh_name"], "Cube")
+
 
 class CrowdNamingTests(unittest.TestCase):
     def test_apply_character_naming_overrides_generated_names(self):
@@ -3634,6 +3648,34 @@ class EyeFingerDispatchTests(unittest.TestCase):
         # Its skin weights collapse into the core target its parent maps to.
         merges = {m["source"]: m["target"] for m in spec["weight_merges"]}
         self.assertEqual(merges.get("DEF-hair"), "Lower_Arm_Left")
+
+    def test_select_body_mesh_unit_scoring_and_tiebreak(self):
+        from asam_human_builder.builder import _select_body_mesh
+        spec_bones = [
+            {"name": "Hip", "source_bone": "Hip"},
+            {"name": "Lower_Spine", "source_bone": "Lower_Spine"},
+        ]
+        weight_merges = [{"source": "DEF-hair", "target": "Upper_Spine"}]
+        mesh_binding = {"meshes": [
+            {"mesh_name": "body", "vertex_group_stats": {"per_group": [
+                {"name": "Hip", "weighted_vertex_count": 100},
+                {"name": "Lower_Spine", "weighted_vertex_count": 50},
+            ]}},
+            {"mesh_name": "hair", "vertex_group_stats": {"per_group": [
+                {"name": "DEF-hair", "weighted_vertex_count": 30},
+            ]}},
+            {"mesh_name": "empty", "vertex_group_stats": {"per_group": [
+                {"name": "Hip", "weighted_vertex_count": 0},
+            ]}},
+        ]}
+        self.assertEqual(_select_body_mesh(mesh_binding, spec_bones, weight_merges), "body")
+
+    def test_select_body_mesh_none_when_no_weighted_core(self):
+        from asam_human_builder.builder import _select_body_mesh
+        self.assertIsNone(_select_body_mesh({"meshes": []}, [], []))
+        self.assertIsNone(_select_body_mesh(
+            {"meshes": [{"mesh_name": "x", "vertex_group_stats": {"per_group": [
+                {"name": "x", "weighted_vertex_count": 0}]}}]}, [], []))
 
 
 if __name__ == "__main__":

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -707,11 +707,11 @@ class AsamHumanBuilderTests(unittest.TestCase):
                 bpy_module.data.objects.get("Armature"),
             )
             mesh.matrix_world = ("source_world", mesh_record["mesh_name"])
-        build_armature_in_blender(build_spec, bpy_module)
-        for mesh_record in build_plan["mesh_binding"]["meshes"]:
-            generated = bpy_module.data.objects.get("ASAM_{0}".format(mesh_record["mesh_name"]))
+        execution_result = build_armature_in_blender(build_spec, bpy_module)
+        for dup in execution_result["duplicated_meshes"]:
+            generated = bpy_module.data.objects.get(dup["generated_mesh_name"])
             self.assertIsNotNone(generated)
-            self.assertEqual(generated.matrix_world, ("source_world", mesh_record["mesh_name"]))
+            self.assertEqual(generated.matrix_world, ("source_world", dup["source_mesh_name"]))
 
     def test_synthesized_path_preserves_source_root_as_sibling_extra(self):
         """When mode == create_new_root and preserve_source_root_as_extra is true,
@@ -1790,8 +1790,9 @@ class CrowdNamingTests(unittest.TestCase):
         generated_armature = bpy_module.data.objects.get(execution_result["generated_armature_name"])
         self.assertIsNotNone(generated_mesh)
         self.assertIn(generated_mesh, generated_collection.all_objects)
-        # Meshes must be children of the generated armature (ASAM hierarchy), not group_root.
-        self.assertIs(generated_mesh.parent, generated_armature)
+        # Meshes are siblings under Grp_Root (ASAM geometry-container hierarchy), not under the armature.
+        group_root = bpy_module.data.objects.get(execution_result["group_root_name"])
+        self.assertIs(generated_mesh.parent, group_root)
         self.assertTrue(generated_mesh.get(GENERATED_MARKER_KEY))
         self.assertEqual(generated_mesh.get(GENERATED_ASSET_KEY), "SyntheticAsset")
         self.assertTrue(generated_mesh.data.get(GENERATED_MARKER_KEY))
@@ -1803,6 +1804,34 @@ class CrowdNamingTests(unittest.TestCase):
         self.assertEqual(execution_result["duplicated_meshes"][0]["source_mesh_name"], "BodyMesh")
         self.assertEqual(execution_result["duplicated_meshes"][0]["generated_mesh_name"], "ASAM_BodyMesh")
         self.assertEqual(execution_result["duplicated_meshes"][0]["retargeted_armature_modifiers"], ["Armature"])
+
+    def test_body_mesh_named_body_container_and_parented_to_grp_root(self):
+        bpy_module = _FakeBpy()
+        source_armature = bpy_module.add_source_armature("Rig")
+        source_mesh = bpy_module.add_source_mesh("BodyMesh", source_armature, armature_modifier=True)
+        source_mesh.vertex_groups = ["Hip"]
+        build_spec = {
+            "asset_name": "SyntheticAsset",
+            "source_armature_name": "Rig",
+            "generated_collection_name": "ASAM_SyntheticAsset",
+            "group_root_name": "Grp_Root",
+            "generated_armature_name": "Armature_SyntheticAsset",
+            "mesh_binding": _mesh_binding("Rig"),
+            "bones": [{"name": "Hip", "parent_bone": None, "head": [0.0, 0.0, 1.0], "tail": [0.0, 0.0, 1.2], "use_connect": False, "geometry_source": "source_bone", "source_bone": "Hip"}],
+            "body_mesh_name": "BodyMesh",
+        }
+
+        execution_result = build_armature_in_blender(build_spec, bpy_module)
+
+        group_root = bpy_module.data.objects.get(execution_result["group_root_name"])
+        generated_armature = bpy_module.data.objects.get(execution_result["generated_armature_name"])
+        body = bpy_module.data.objects.get("Body_SyntheticAsset")
+        self.assertIsNotNone(body)
+        self.assertIs(body.parent, group_root)
+        self.assertIs(body.modifiers[0].object, generated_armature)
+        dup = execution_result["duplicated_meshes"][0]
+        self.assertEqual(dup["generated_mesh_name"], "Body_SyntheticAsset")
+        self.assertEqual(dup["role"], "body")
 
     def test_blender_builder_duplicates_parent_only_mesh_with_warning(self):
         bpy_module = _FakeBpy()
@@ -1878,8 +1907,8 @@ class CrowdNamingTests(unittest.TestCase):
             ["Armature"],
         )
 
-    def test_blender_builder_parents_mesh_to_armature_not_group_root(self):
-        """Generated meshes must be one level below the armature in the ASAM hierarchy."""
+    def test_blender_builder_parents_mesh_to_grp_root_not_armature(self):
+        """Generated meshes are siblings of the armature under Grp_Root (geometry-container hierarchy)."""
         bpy_module = _FakeBpy()
         source_armature = bpy_module.add_source_armature("Rig")
         bpy_module.add_source_mesh("BodyMesh", source_armature, armature_modifier=True)
@@ -1900,9 +1929,9 @@ class CrowdNamingTests(unittest.TestCase):
         group_root = bpy_module.data.objects.get(execution_result["group_root_name"])
         self.assertIsNotNone(generated_mesh)
         self.assertIsNotNone(generated_armature)
-        # Mesh parent must be the armature, not the group root.
-        self.assertIs(generated_mesh.parent, generated_armature)
-        self.assertIsNot(generated_mesh.parent, group_root)
+        # Mesh parent must be Grp_Root (sibling of armature), not the armature itself.
+        self.assertIs(generated_mesh.parent, group_root)
+        self.assertIsNot(generated_mesh.parent, generated_armature)
         # The armature itself must still be parented to group_root.
         self.assertIs(generated_armature.parent, group_root)
 
@@ -3153,8 +3182,9 @@ class WeightMergeAndPurgeExecutionTests(unittest.TestCase):
              "modifiers": [{"stack_index": 0, "type": "ARMATURE", "name": "Armature", "object": "Rig"}],
              "vertex_groups": ["Spine0", "Spine1", "Spine3", "Spine4", "Other"]}]}
 
-        build_armature_in_blender(spec, bpy_module)
-        result_mesh = bpy_module.data.objects.get("ASAM_BodyMesh")
+        execution_result = build_armature_in_blender(spec, bpy_module)
+        generated_mesh_name = execution_result["duplicated_meshes"][0]["generated_mesh_name"]
+        result_mesh = bpy_module.data.objects.get(generated_mesh_name)
         groups = set(result_mesh.vertex_groups)
         self.assertIn("Lower_Spine", groups)
         self.assertIn("Upper_Spine", groups)


### PR DESCRIPTION
Implements the rescoped #68 (decorator/geometry containers), Approach B.

## What changed
- **Name-free body-mesh selection** (`builder.py::_select_body_mesh`): scores each bound mesh by weighted core-skeleton coverage; result stored as `build_spec["body_mesh_name"]`. openmatexamplehuman → `Body_Human`; LowPolyCharacter4 → `Cube`.
- **Spec-correct geometry hierarchy** (`blender_builder.py`): every duplicated mesh is now parented as a **sibling of `Armature_<Name>` under `Grp_Root`** (was: under the armature). The body mesh is named **`Body_<AssetName>`**; other meshes stay `ASAM_<source>`. Each `duplicated_meshes` report entry gains `role` (body/extra) and `parent`.
- Deformation unchanged (armature *modifier* retarget retained; only the object parent moved); world transform preserved.
- No hair/clothing/accessory sub-classification (spec doesn't require it).

## Why
Previously the builder copied every bound mesh as `ASAM_<name>` flattened under the armature — so even the already-compliant openmatexamplehuman came out *less* spec-faithful (prefixed names, flattened hierarchy). This reproduces the ASAM geometry-container structure for arbitrary rigs.

## Tests
TDD throughout. New body-selection tests (incl. fixtures), updated Blender-duplication tests to the Grp_Root hierarchy, refreshed golden builder reports. Full suite: **364 green**.

Closes #68.