### PR TITLE
feat: add source/generated visibility toggles to Build Results panel

### DIFF
--- a/addon/__init__.py
+++ b/addon/__init__.py
@@ -76,6 +76,7 @@ def load_post_handler(dummy1, dummy2=None):
             s.synthesized_bones_by_character_csv = ""
             s.show_failed_details = False
             s.show_inert_details = False
+            s.show_source = True
 
 
 def register():

--- a/addon/operators.py
+++ b/addon/operators.py
@@ -27,6 +27,7 @@ class OJ_OT_run_pipeline(bpy.types.Operator):
         settings.synthesized_bones_csv = ""
         settings.synthesized_bones_by_character_csv = ""
         settings.show_generated_armature = True
+        settings.show_source = True  # un-hide any source objects from a prior build
 
         prefs = _addon_prefs(context)
         if prefs.output_dir:
@@ -121,6 +122,7 @@ class OJ_OT_build(bpy.types.Operator):
         report_path = asset_dir / "builder_report.json"
         self.report({'INFO'}, success_message(report, report_path))
         settings.built = True
+        settings.show_source = False  # source objects were hidden by the build
 
         if "characters" in report:
             settings.build_succeeded = len(report.get("characters", []))
@@ -292,6 +294,7 @@ class OJ_OT_clean(bpy.types.Operator):
     def execute(self, context):
         removed = purge_previous_generated_artifacts(bpy)
         s = context.scene.open_jaywalker
+        s.show_source = True  # restore source objects before marking as unbuilt
         s.built = False
         s.synthesized_bones_csv = ""
         s.synthesized_bones_by_character_csv = ""
@@ -308,7 +311,8 @@ class OJ_OT_reset_pipeline(bpy.types.Operator):
     def execute(self, context):
         purge_previous_generated_artifacts(bpy)
         s = context.scene.open_jaywalker
-        
+        s.show_source = True  # restore source objects before clearing state
+
         if s.asset_dir:
             path = Path(s.asset_dir)
             if path.exists() and path.is_dir():

--- a/addon/state.py
+++ b/addon/state.py
@@ -17,23 +17,54 @@ def update_show_generated_armature(self, context):
     for obj in objects:
         if obj is None:
             continue
-        if getattr(obj, "type", None) == "ARMATURE":
-            is_generated = False
-            if hasattr(obj, "get") and callable(obj.get):
+        is_generated = False
+        if hasattr(obj, "get") and callable(obj.get):
+            try:
+                is_generated = bool(obj.get("open_jaywalker_generated"))
+            except Exception:
+                pass
+        if not is_generated:
+            is_generated = bool(getattr(obj, "open_jaywalker_generated", False))
+
+        if is_generated:
+            hide_set = getattr(obj, "hide_set", None)
+            if callable(hide_set):
                 try:
-                    is_generated = bool(obj.get("open_jaywalker_generated"))
+                    hide_set(not show)
                 except Exception:
                     pass
-            if not is_generated:
-                is_generated = bool(getattr(obj, "open_jaywalker_generated", False))
 
-            if is_generated:
-                hide_set = getattr(obj, "hide_set", None)
-                if callable(hide_set):
-                    try:
-                        hide_set(not show)
-                    except Exception:
-                        pass
+
+def update_show_source(self, context):
+    if context is None:
+        return
+    scene = getattr(context, "scene", None)
+    if scene is None:
+        return
+    objects = getattr(scene, "objects", None)
+    if objects is None:
+        return
+
+    show = getattr(self, "show_source", True)
+    for obj in objects:
+        if obj is None:
+            continue
+        is_source = False
+        if hasattr(obj, "get") and callable(obj.get):
+            try:
+                is_source = bool(obj.get("open_jaywalker_source_hidden"))
+            except Exception:
+                pass
+        if not is_source:
+            is_source = bool(getattr(obj, "open_jaywalker_source_hidden", False))
+
+        if is_source:
+            hide_set = getattr(obj, "hide_set", None)
+            if callable(hide_set):
+                try:
+                    hide_set(not show)
+                except Exception:
+                    pass
 
 
 class OJSettings(bpy.types.PropertyGroup):
@@ -41,10 +72,16 @@ class OJSettings(bpy.types.PropertyGroup):
     built: bpy.props.BoolProperty(default=False)
     show_details: bpy.props.BoolProperty(default=False)
     show_generated_armature: bpy.props.BoolProperty(
-        name="Show Armature",
-        description="Show or hide the generated ASAM armature(s) in the viewport",
+        name="Show generated",
+        description="Show or hide the generated ASAM rig and meshes in the viewport",
         default=True,
         update=update_show_generated_armature,
+    )
+    show_source: bpy.props.BoolProperty(
+        name="Show source",
+        description="Show or hide the original source rig and meshes in the viewport",
+        default=True,
+        update=update_show_source,
     )
     asset_dir: bpy.props.StringProperty(default="")
     export_dir: bpy.props.StringProperty(default="")

--- a/addon/ui.py
+++ b/addon/ui.py
@@ -83,6 +83,7 @@ class OJ_PT_panel(bpy.types.Panel):
             res_box.label(text="Build Results", icon='INFO')
             res_col = res_box.column(align=True)
             res_col.prop(s, "show_generated_armature")
+            res_col.prop(s, "show_source")
             if s.is_crowd:
                 res_col.label(text="Succeeded: {0}".format(s.build_succeeded), icon='CHECKMARK')
                 if s.build_failed > 0:

--- a/src/asam_human_builder/blender_builder.py
+++ b/src/asam_human_builder/blender_builder.py
@@ -23,6 +23,8 @@ except ImportError:  # pragma: no cover - Blender script path fallback
     )
 
 
+SOURCE_HIDDEN_MARKER_KEY = "open_jaywalker_source_hidden"
+
 _EXTREMITY_BONES_TO_HIDE = {
     "Full_Thumb_Left",
     "Full_Thumb_Right",
@@ -158,8 +160,27 @@ def _hide_source_objects(bpy_module, source_armature, build_spec) -> List[str]:
             targets.append(mesh)
     for obj in targets:
         obj.hide_set(True)
+        obj[SOURCE_HIDDEN_MARKER_KEY] = True
         hidden.append(obj.name)
     return hidden
+
+
+def show_source_objects(bpy_module) -> int:
+    """Un-hide all source objects hidden by a previous build and remove their marker.
+
+    Returns the number of objects shown.
+    """
+    shown = 0
+    for obj in list(bpy_module.data.objects):
+        if not obj.get(SOURCE_HIDDEN_MARKER_KEY):
+            continue
+        obj.hide_set(False)
+        try:
+            del obj[SOURCE_HIDDEN_MARKER_KEY]
+        except Exception:
+            pass
+        shown += 1
+    return shown
 
 
 def purge_previous_generated_artifacts(bpy_module) -> int:

--- a/tests/test_addon_interface.py
+++ b/tests/test_addon_interface.py
@@ -86,7 +86,9 @@ class AddonInterfaceTests(unittest.TestCase):
             built=True,
             synthesized_bones_csv="Full_Fingers_Left",
             synthesized_bones_by_character_csv="char0 (Full_Fingers_Left)",
-            export_dir="some_dir"
+            export_dir="some_dir",
+            show_source=False,
+            show_generated_armature=True,
         )
         mock_context = types.SimpleNamespace(
             scene=types.SimpleNamespace(open_jaywalker=mock_settings),
@@ -134,7 +136,8 @@ class AddonInterfaceTests(unittest.TestCase):
             build_failed=0,
             failed_characters_csv="",
             synthesized_bones_csv="",
-            synthesized_bones_by_character_csv=""
+            synthesized_bones_by_character_csv="",
+            show_source=True,
         )
         mock_context = types.SimpleNamespace(
             scene=types.SimpleNamespace(open_jaywalker=mock_settings),
@@ -161,7 +164,8 @@ class AddonInterfaceTests(unittest.TestCase):
             self.assertTrue(mock_settings.built)
             self.assertEqual(mock_settings.synthesized_bones_csv, "Full_Fingers_Left, Full_Fingers_Right")
             self.assertEqual(mock_settings.synthesized_bones_by_character_csv, "")
-            
+            self.assertFalse(mock_settings.show_source)
+
             build_op.report.assert_any_call(
                 {'WARNING'},
                 "Synthesized inert bones added for compliance: Full_Fingers_Left, Full_Fingers_Right"
@@ -180,7 +184,8 @@ class AddonInterfaceTests(unittest.TestCase):
             build_failed=0,
             failed_characters_csv="",
             synthesized_bones_csv="",
-            synthesized_bones_by_character_csv=""
+            synthesized_bones_by_character_csv="",
+            show_source=True,
         )
         mock_context = types.SimpleNamespace(
             scene=types.SimpleNamespace(open_jaywalker=mock_settings),
@@ -235,7 +240,8 @@ class AddonInterfaceTests(unittest.TestCase):
             build_failed=0,
             failed_characters_csv="",
             synthesized_bones_csv="",
-            synthesized_bones_by_character_csv=""
+            synthesized_bones_by_character_csv="",
+            show_source=True,
         )
         mock_context = types.SimpleNamespace(
             scene=types.SimpleNamespace(open_jaywalker=mock_settings),
@@ -459,19 +465,21 @@ class AddonInterfaceTests(unittest.TestCase):
         )
 
         self.state.update_show_generated_armature(mock_settings, mock_context)
-        
+
         mock_generated_armature.hide_set.assert_called_once_with(True)
-        mock_other_object.hide_set.assert_not_called()
+        mock_other_object.hide_set.assert_called_once_with(True)  # generated mesh is now covered
         mock_non_gen_armature.hide_set.assert_not_called()
         mock_dict_gen_armature.hide_set.assert_called_once_with(True)
         mock_dict_non_gen_armature.hide_set.assert_not_called()
-        
+
         mock_generated_armature.hide_set.reset_mock()
+        mock_other_object.hide_set.reset_mock()
         mock_dict_gen_armature.hide_set.reset_mock()
 
         mock_settings.show_generated_armature = True
         self.state.update_show_generated_armature(mock_settings, mock_context)
         mock_generated_armature.hide_set.assert_called_once_with(False)
+        mock_other_object.hide_set.assert_called_once_with(False)
         mock_dict_gen_armature.hide_set.assert_called_once_with(False)
 
         # 2. Test that UI renders the checkbox without crashing
@@ -525,16 +533,50 @@ class AddonInterfaceTests(unittest.TestCase):
             export_gltf=True,
             per_character_export=False,
             show_generated_armature=True,
+            show_source=False,
             show_failed_details=False,
             show_inert_details=False
         )
         ui_context = types.SimpleNamespace(scene=types.SimpleNamespace(open_jaywalker=ui_settings))
-        
+
         panel = self.ui.OJ_PT_panel()
         panel.layout = mock_layout
         panel.draw(ui_context)
-        
+
         self.assertIn((ui_settings, "show_generated_armature"), mock_layout.props_drawn)
+        self.assertIn((ui_settings, "show_source"), mock_layout.props_drawn)
+
+    def test_show_source_toggle(self):
+        """update_show_source shows/hides objects stamped with open_jaywalker_source_hidden."""
+        class DictLikeMockObj:
+            def __init__(self, marker_val):
+                self.props = {"open_jaywalker_source_hidden": marker_val}
+                self.hide_set = mock.Mock()
+            def get(self, key, default=None):
+                return self.props.get(key, default)
+
+        marked_arm = DictLikeMockObj(True)
+        marked_mesh = DictLikeMockObj(True)
+        unmarked = DictLikeMockObj(False)
+
+        mock_settings = types.SimpleNamespace(show_source=False)
+        mock_context = types.SimpleNamespace(
+            scene=types.SimpleNamespace(objects=[marked_arm, marked_mesh, unmarked, None])
+        )
+
+        self.state.update_show_source(mock_settings, mock_context)
+
+        marked_arm.hide_set.assert_called_once_with(True)
+        marked_mesh.hide_set.assert_called_once_with(True)
+        unmarked.hide_set.assert_not_called()
+
+        marked_arm.hide_set.reset_mock()
+        marked_mesh.hide_set.reset_mock()
+
+        mock_settings.show_source = True
+        self.state.update_show_source(mock_settings, mock_context)
+        marked_arm.hide_set.assert_called_once_with(False)
+        marked_mesh.hide_set.assert_called_once_with(False)
 
     def test_reset_pipeline_operator(self):
         import tempfile
@@ -565,7 +607,8 @@ class AddonInterfaceTests(unittest.TestCase):
             synthesized_bones_csv="bone1",
             synthesized_bones_by_character_csv="char1 (bone1)",
             show_failed_details=True,
-            show_inert_details=True
+            show_inert_details=True,
+            show_source=False,
         )
         mock_context = types.SimpleNamespace(
             scene=types.SimpleNamespace(open_jaywalker=mock_settings)
@@ -615,6 +658,7 @@ class AddonInterfaceTests(unittest.TestCase):
         self.assertEqual(mock_settings.synthesized_bones_by_character_csv, "")
         self.assertFalse(mock_settings.show_failed_details)
         self.assertFalse(mock_settings.show_inert_details)
+        self.assertTrue(mock_settings.show_source)
 
     def test_load_post_handler_resets_properties(self):
         # We need to test the load_post_handler defined in addon.__init__
@@ -643,7 +687,8 @@ class AddonInterfaceTests(unittest.TestCase):
             synthesized_bones_csv="bone1",
             synthesized_bones_by_character_csv="char1 (bone1)",
             show_failed_details=True,
-            show_inert_details=True
+            show_inert_details=True,
+            show_source=False,
         )
         
         # Set up fake_bpy.context
@@ -676,6 +721,7 @@ class AddonInterfaceTests(unittest.TestCase):
         self.assertEqual(mock_settings.synthesized_bones_by_character_csv, "")
         self.assertFalse(mock_settings.show_failed_details)
         self.assertFalse(mock_settings.show_inert_details)
+        self.assertTrue(mock_settings.show_source)
 
     def test_ui_draw_collapsible_sections_and_reset_button(self):
         class MockLayout:

--- a/tests/test_asam_human_builder.py
+++ b/tests/test_asam_human_builder.py
@@ -229,6 +229,9 @@ class _FakeProps:
     def __setitem__(self, key, value):
         self._props[key] = value
 
+    def __delitem__(self, key):
+        del self._props[key]
+
     def get(self, key, default=None):
         return self._props.get(key, default)
 
@@ -674,6 +677,42 @@ class AsamHumanBuilderTests(unittest.TestCase):
         hidden2 = _hide_source_objects(bpy_module, source_arm, build_spec)
         self.assertIn("metarig", hidden2)
         self.assertTrue(metarig_obj.hide_get())
+
+    def test_hide_source_objects_stamps_marker(self):
+        """_hide_source_objects stamps SOURCE_HIDDEN_MARKER_KEY on each hidden object."""
+        from asam_human_builder.blender_builder import _hide_source_objects, SOURCE_HIDDEN_MARKER_KEY
+        bpy_module = _FakeBpy()
+        source_arm = bpy_module.add_source_armature("Armature")
+        mesh_data = bpy_module.data.meshes.new("Body")
+        mesh_obj = bpy_module.data.objects.new("Body", mesh_data)
+        build_spec = {"mesh_binding": {"meshes": [{"mesh_name": "Body"}]}}
+        _hide_source_objects(bpy_module, source_arm, build_spec)
+        self.assertTrue(bool(source_arm.get(SOURCE_HIDDEN_MARKER_KEY)))
+        self.assertTrue(bool(mesh_obj.get(SOURCE_HIDDEN_MARKER_KEY)))
+
+    def test_show_source_objects_unhides_and_removes_marker(self):
+        """show_source_objects un-hides all stamped source objects and removes the marker."""
+        from asam_human_builder.blender_builder import show_source_objects, SOURCE_HIDDEN_MARKER_KEY
+        bpy_module = _FakeBpy()
+        arm_data = bpy_module.data.armatures.new("Rig")
+        arm_obj = bpy_module.data.objects.new("Rig", arm_data)
+        arm_obj.hide_set(True)
+        arm_obj[SOURCE_HIDDEN_MARKER_KEY] = True
+        mesh_data = bpy_module.data.meshes.new("Body")
+        mesh_obj = bpy_module.data.objects.new("Body", mesh_data)
+        mesh_obj.hide_set(True)
+        mesh_obj[SOURCE_HIDDEN_MARKER_KEY] = True
+        non_marked = bpy_module.data.objects.new("Other", bpy_module.data.meshes.new("Other"))
+        non_marked.hide_set(True)
+
+        count = show_source_objects(bpy_module)
+
+        self.assertEqual(count, 2)
+        self.assertFalse(arm_obj.hide_get())
+        self.assertFalse(mesh_obj.hide_get())
+        self.assertTrue(non_marked.hide_get())
+        self.assertFalse(bool(arm_obj.get(SOURCE_HIDDEN_MARKER_KEY)))
+        self.assertFalse(bool(mesh_obj.get(SOURCE_HIDDEN_MARKER_KEY)))
 
     def test_grp_root_location_set_to_bbox_ground_center(self):
         """Grp_Root empty's location must equal the source-frame bbox_ground_center."""


### PR DESCRIPTION
## Summary

- Adds **Show source** toggle: after a build, the original rig + meshes can be shown/hides from the Build Results panel via a marker stamped on each hidden object (`open_jaywalker_source_hidden`)
- Expands **Show generated** toggle to cover generated meshes in addition to armatures (especially useful in crowd builds where both rig and skin need to disappear together)
- Source objects are automatically restored when Clean, Reset, or Run pipeline is pressed
- 375 tests passing

## Test plan

- [x] `test_hide_source_objects_stamps_marker` — verifies marker is set on hidden objects
- [x] `test_show_source_objects_unhides_and_removes_marker` — verifies toggle un-hides and cleans up marker
- [x] `test_show_source_toggle` — verifies `update_show_source` callback hides/shows correctly
- [x] `test_show_generated_armature_toggle_and_ui` — updated to verify generated meshes are also covered
- [x] Existing operator/reset/load-handler tests updated for new `show_source` state field